### PR TITLE
Error handling

### DIFF
--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -110,8 +110,8 @@ fn init(p: init::Peripherals) -> init::LateResources {
     let mut disp = Builder::new().connect_spi(spi, dc);
 
     disp.reset(&mut rst, &mut delay);
-    disp.init();
-    disp.flush();
+    disp.init().unwrap();
+    disp.flush().unwrap();
 
     init::LateResources {
         DISP: disp,
@@ -157,7 +157,7 @@ fn idle(_t: &mut Threshold, r: idle::Resources) -> ! {
             false => draw_square(&mut disp, 6, 0),
         }
 
-        disp.flush();
+        disp.flush().unwrap();
 
         *state = !*state;
     }

--- a/examples/graphics.rs
+++ b/examples/graphics.rs
@@ -59,8 +59,8 @@ fn main() {
     let mut disp = Builder::new().connect_spi(spi, dc);
 
     disp.reset(&mut rst, &mut delay);
-    disp.init();
-    disp.flush();
+    disp.init().unwrap();
+    disp.flush().unwrap();
 
     disp.draw(Line::new((8, 16 + 16), (8 + 16, 16 + 16), 1).into_iter());
     disp.draw(Line::new((8, 16 + 16), (8 + 8, 16), 1).into_iter());
@@ -70,5 +70,5 @@ fn main() {
 
     disp.draw(Circle::new((96, 16 + 8), 8, 1u8).into_iter());
 
-    disp.flush();
+    disp.flush().unwrap();
 }

--- a/examples/graphics_i2c.rs
+++ b/examples/graphics_i2c.rs
@@ -45,8 +45,8 @@ fn main() {
     );
 
     let mut disp = Builder::new().connect_i2c(i2c);
-    disp.init();
-    disp.flush();
+    disp.init().unwrap();
+    disp.flush().unwrap();
 
     disp.draw(Line::new((8, 16 + 16), (8 + 16, 16 + 16), 1).into_iter());
     disp.draw(Line::new((8, 16 + 16), (8 + 8, 16), 1).into_iter());
@@ -56,5 +56,5 @@ fn main() {
 
     disp.draw(Circle::new((96, 16 + 8), 8, 1u8).into_iter());
 
-    disp.flush();
+    disp.flush().unwrap();
 }

--- a/examples/graphics_i2c_128x32.rs
+++ b/examples/graphics_i2c_128x32.rs
@@ -48,8 +48,8 @@ fn main() {
     let mut disp = Builder::new()
         .with_size(DisplaySize::Display128x32)
         .connect_i2c(i2c);
-    disp.init();
-    disp.flush();
+    disp.init().unwrap();
+    disp.flush().unwrap();
 
     let yoffset = 8;
 
@@ -61,5 +61,5 @@ fn main() {
 
     disp.draw(Circle::new((96, yoffset + 8), 8, 1u8).into_iter());
 
-    disp.flush();
+    disp.flush().unwrap();
 }

--- a/examples/pixelsquare.rs
+++ b/examples/pixelsquare.rs
@@ -57,8 +57,8 @@ fn main() {
     let mut disp = Builder::new().connect_spi(spi, dc);
 
     disp.reset(&mut rst, &mut delay);
-    disp.init();
-    disp.flush();
+    disp.init().unwrap();
+    disp.flush().unwrap();
 
     // Top side
     disp.set_pixel(0, 0, 1);
@@ -84,5 +84,5 @@ fn main() {
     disp.set_pixel(0, 2, 1);
     disp.set_pixel(0, 3, 1);
 
-    disp.flush();
+    disp.flush().unwrap();
 }

--- a/examples/text_i2c.rs
+++ b/examples/text_i2c.rs
@@ -45,11 +45,11 @@ fn main() {
     );
 
     let mut disp = Builder::new().connect_i2c(i2c);
-    disp.init();
-    disp.flush();
+    disp.init().unwrap();
+    disp.flush().unwrap();
 
     disp.draw(Font6x8::render_str("Hello world!", (0, 0)).into_iter());
     disp.draw(Font6x8::render_str("Hello Rust!", (0, 16)).into_iter());
 
-    disp.flush();
+    disp.flush().unwrap();
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -84,113 +84,115 @@ pub enum Command {
 
 impl Command {
     /// Send command to SSD1306
-    pub fn send<Interface>(&self, iface: &mut Interface)
+    pub fn send<DI>(&self, iface: &mut DI) -> Result<(), DI::Error>
     where
-        Interface: DisplayInterface,
+        DI: DisplayInterface,
     {
         match *self {
             Command::Contrast(val) => {
-                iface.send_command(0x81);
-                iface.send_command(val);
+                iface.send_command(0x81)?;
+                iface.send_command(val)?;
             }
             Command::AllOn(on) => {
-                iface.send_command(0xA4 | (on as u8));
+                iface.send_command(0xA4 | (on as u8))?;
             }
             Command::Invert(inv) => {
-                iface.send_command(0xA6 | (inv as u8));
+                iface.send_command(0xA6 | (inv as u8))?;
             }
             Command::DisplayOn(on) => {
-                iface.send_command(0xAE | (on as u8));
+                iface.send_command(0xAE | (on as u8))?;
             }
             Command::HScrollSetup(dir, start, end, rate) => {
-                iface.send_command(0x26 | (dir as u8));
-                iface.send_command(0);
-                iface.send_command(start as u8);
-                iface.send_command(rate as u8);
-                iface.send_command(end as u8);
-                iface.send_command(0);
-                iface.send_command(0xFF);
+                iface.send_command(0x26 | (dir as u8))?;
+                iface.send_command(0)?;
+                iface.send_command(start as u8)?;
+                iface.send_command(rate as u8)?;
+                iface.send_command(end as u8)?;
+                iface.send_command(0)?;
+                iface.send_command(0xFF)?;
             }
             Command::VHScrollSetup(dir, start, end, rate, offset) => {
-                iface.send_command(0x28 | (dir as u8));
-                iface.send_command(0);
-                iface.send_command(start as u8);
-                iface.send_command(rate as u8);
-                iface.send_command(end as u8);
-                iface.send_command(offset);
+                iface.send_command(0x28 | (dir as u8))?;
+                iface.send_command(0)?;
+                iface.send_command(start as u8)?;
+                iface.send_command(rate as u8)?;
+                iface.send_command(end as u8)?;
+                iface.send_command(offset)?;
             }
             Command::EnableScroll(en) => {
-                iface.send_command(0x2E | (en as u8));
+                iface.send_command(0x2E | (en as u8))?;
             }
             Command::VScrollArea(above, lines) => {
-                iface.send_command(0xA3);
-                iface.send_command(above);
-                iface.send_command(lines);
+                iface.send_command(0xA3)?;
+                iface.send_command(above)?;
+                iface.send_command(lines)?;
             }
             Command::LowerColStart(addr) => {
-                iface.send_command(0xF & addr);
+                iface.send_command(0xF & addr)?;
             }
             Command::UpperColStart(addr) => {
-                iface.send_command(0x1F & addr);
+                iface.send_command(0x1F & addr)?;
             }
             Command::AddressMode(mode) => {
-                iface.send_command(0x20);
-                iface.send_command(mode as u8);
+                iface.send_command(0x20)?;
+                iface.send_command(mode as u8)?;
             }
             Command::ColumnAddress(start, end) => {
-                iface.send_command(0x21);
-                iface.send_command(start);
-                iface.send_command(end);
+                iface.send_command(0x21)?;
+                iface.send_command(start)?;
+                iface.send_command(end)?;
             }
             Command::PageAddress(start, end) => {
-                iface.send_command(0x22);
-                iface.send_command(start as u8);
-                iface.send_command(end as u8);
+                iface.send_command(0x22)?;
+                iface.send_command(start as u8)?;
+                iface.send_command(end as u8)?;
             }
             Command::PageStart(page) => {
-                iface.send_command(0xB0 | (page as u8));
+                iface.send_command(0xB0 | (page as u8))?;
             }
             Command::StartLine(line) => {
-                iface.send_command(0x40 | (0x3F & line));
+                iface.send_command(0x40 | (0x3F & line))?;
             }
             Command::SegmentRemap(remap) => {
-                iface.send_command(0xA0 | (remap as u8));
+                iface.send_command(0xA0 | (remap as u8))?;
             }
             Command::Multiplex(ratio) => {
-                iface.send_command(0xA8);
-                iface.send_command(ratio);
+                iface.send_command(0xA8)?;
+                iface.send_command(ratio)?;
             }
             Command::ReverseComDir(rev) => {
-                iface.send_command(0xC0 | ((rev as u8) << 3));
+                iface.send_command(0xC0 | ((rev as u8) << 3))?;
             }
             Command::DisplayOffset(offset) => {
-                iface.send_command(0xD3);
-                iface.send_command(offset);
+                iface.send_command(0xD3)?;
+                iface.send_command(offset)?;
             }
             Command::ComPinConfig(alt, lr) => {
-                iface.send_command(0xDA);
-                iface.send_command(0x2 | ((alt as u8) << 4) | ((lr as u8) << 5));
+                iface.send_command(0xDA)?;
+                iface.send_command(0x2 | ((alt as u8) << 4) | ((lr as u8) << 5))?;
             }
             Command::DisplayClockDiv(fosc, div) => {
-                iface.send_command(0xD5);
-                iface.send_command(((0xF & fosc) << 4) | (0xF & div));
+                iface.send_command(0xD5)?;
+                iface.send_command(((0xF & fosc) << 4) | (0xF & div))?;
             }
             Command::PreChargePeriod(phase1, phase2) => {
-                iface.send_command(0xD9);
-                iface.send_command(((0xF & phase2) << 4) | (0xF & phase1));
+                iface.send_command(0xD9)?;
+                iface.send_command(((0xF & phase2) << 4) | (0xF & phase1))?;
             }
             Command::VcomhDeselect(level) => {
-                iface.send_command(0xDB);
-                iface.send_command((level as u8) << 4);
+                iface.send_command(0xDB)?;
+                iface.send_command((level as u8) << 4)?;
             }
             Command::Noop => {
-                iface.send_command(0xE3);
+                iface.send_command(0xE3)?;
             }
             Command::ChargePump(en) => {
-                iface.send_command(0x8D);
-                iface.send_command(0x10 | ((en as u8) << 2));
+                iface.send_command(0x8D)?;
+                iface.send_command(0x10 | ((en as u8) << 2))?;
             }
         }
+
+        Ok(())
     }
 }
 

--- a/src/interface/i2c.rs
+++ b/src/interface/i2c.rs
@@ -19,13 +19,17 @@ impl<I2C> DisplayInterface for I2cInterface<I2C>
 where
     I2C: hal::blocking::i2c::Write,
 {
-    fn send_command(&mut self, cmd: u8) {
-        self.i2c.write(0x3c, &[0, cmd]);
+    type Error = I2C::Error;
+
+    fn send_command(&mut self, cmd: u8) -> Result<(), I2C::Error> {
+        self.i2c.write(0x3c, &[0, cmd])?;
+
+        Ok(())
     }
 
     // TODO: Send data in chunks to save memory. This code is particularly bad with 128x32 displays
     // as half of `writebuf` is completely wasted.
-    fn send_data(&mut self, buf: &[u8]) {
+    fn send_data(&mut self, buf: &[u8]) -> Result<(), I2C::Error> {
         let mut writebuf: [u8; 1025] = [0; 1025];
 
         // Data mode
@@ -36,6 +40,8 @@ where
             writebuf[index + 1] = *byte;
         }
 
-        self.i2c.write(0x3c, &writebuf[0..buf.len() + 1]);
+        self.i2c.write(0x3c, &writebuf[0..buf.len() + 1])?;
+
+        Ok(())
     }
 }

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -2,8 +2,10 @@ pub mod i2c;
 pub mod spi;
 
 pub trait DisplayInterface {
-    fn send_command(&mut self, cmd: u8);
-    fn send_data(&mut self, buf: &[u8]);
+    type Error;
+
+    fn send_command(&mut self, cmd: u8) -> Result<(), Self::Error>;
+    fn send_data(&mut self, buf: &[u8]) -> Result<(), Self::Error>;
 }
 
 pub use self::i2c::I2cInterface;

--- a/src/interface/spi.rs
+++ b/src/interface/spi.rs
@@ -10,7 +10,7 @@ pub struct SpiInterface<SPI, DC> {
 
 impl<SPI, DC> SpiInterface<SPI, DC>
 where
-    SPI: hal::blocking::spi::Transfer<u8> + hal::blocking::spi::Write<u8>,
+    SPI: hal::blocking::spi::Write<u8>,
     DC: OutputPin,
 {
     pub fn new(spi: SPI, dc: DC) -> Self {
@@ -20,21 +20,27 @@ where
 
 impl<SPI, DC> DisplayInterface for SpiInterface<SPI, DC>
 where
-    SPI: hal::blocking::spi::Transfer<u8> + hal::blocking::spi::Write<u8>,
+    SPI: hal::blocking::spi::Write<u8>,
     DC: OutputPin,
 {
-    fn send_command(&mut self, cmd: u8) {
+    type Error = SPI::Error;
+
+    fn send_command(&mut self, cmd: u8) -> Result<(), SPI::Error> {
         self.dc.set_low();
 
-        self.spi.write(&[cmd]);
+        self.spi.write(&[cmd])?;
 
         self.dc.set_high();
+
+        Ok(())
     }
 
-    fn send_data(&mut self, buf: &[u8]) {
+    fn send_data(&mut self, buf: &[u8]) -> Result<(), SPI::Error> {
         // 1 = data, 0 = command
         self.dc.set_high();
 
-        self.spi.write(&buf);
+        self.spi.write(&buf)?;
+
+        Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,11 +63,11 @@ where
         rst.set_high();
     }
 
-    pub fn flush(&mut self) {
+    pub fn flush(&mut self) -> Result<(), DI::Error> {
         let (display_width, display_height) = self.display_size.dimensions();
 
-        Command::ColumnAddress(0, display_width - 1).send(&mut self.iface);
-        Command::PageAddress(0.into(), (display_height - 1).into()).send(&mut self.iface);
+        Command::ColumnAddress(0, display_width - 1).send(&mut self.iface)?;
+        Command::PageAddress(0.into(), (display_height - 1).into()).send(&mut self.iface)?;
 
         match self.display_size {
             DisplaySize::Display128x64 => self.iface.send_data(&self.buffer),
@@ -90,33 +90,35 @@ where
     }
 
     // Display is set up in column mode, i.e. a byte walks down a column of 8 pixels from column 0 on the left, to column _n_ on the right
-    pub fn init(&mut self) {
+    pub fn init(&mut self) -> Result<(), DI::Error> {
         let (_, display_height) = self.display_size.dimensions();
 
-        Command::DisplayOn(false).send(&mut self.iface);
-        Command::DisplayClockDiv(0x8, 0x0).send(&mut self.iface);
-        Command::Multiplex(display_height - 1).send(&mut self.iface);
-        Command::DisplayOffset(0).send(&mut self.iface);
-        Command::StartLine(0).send(&mut self.iface);
+        Command::DisplayOn(false).send(&mut self.iface)?;
+        Command::DisplayClockDiv(0x8, 0x0).send(&mut self.iface)?;
+        Command::Multiplex(display_height - 1).send(&mut self.iface)?;
+        Command::DisplayOffset(0).send(&mut self.iface)?;
+        Command::StartLine(0).send(&mut self.iface)?;
         // TODO: Ability to turn charge pump on/off
-        Command::ChargePump(true).send(&mut self.iface);
-        Command::AddressMode(AddrMode::Horizontal).send(&mut self.iface);
-        Command::SegmentRemap(true).send(&mut self.iface);
-        Command::ReverseComDir(true).send(&mut self.iface);
+        Command::ChargePump(true).send(&mut self.iface)?;
+        Command::AddressMode(AddrMode::Horizontal).send(&mut self.iface)?;
+        Command::SegmentRemap(true).send(&mut self.iface)?;
+        Command::ReverseComDir(true).send(&mut self.iface)?;
 
         match self.display_size {
             DisplaySize::Display128x32 => Command::ComPinConfig(false, false).send(&mut self.iface),
             DisplaySize::Display128x64 => Command::ComPinConfig(true, false).send(&mut self.iface),
             DisplaySize::Display96x16 => Command::ComPinConfig(false, false).send(&mut self.iface),
-        }
+        }?;
 
-        Command::Contrast(0x8F).send(&mut self.iface);
-        Command::PreChargePeriod(0x1, 0xF).send(&mut self.iface);
-        Command::VcomhDeselect(VcomhLevel::Auto).send(&mut self.iface);
-        Command::AllOn(false).send(&mut self.iface);
-        Command::Invert(false).send(&mut self.iface);
-        Command::EnableScroll(false).send(&mut self.iface);
-        Command::DisplayOn(true).send(&mut self.iface);
+        Command::Contrast(0x8F).send(&mut self.iface)?;
+        Command::PreChargePeriod(0x1, 0xF).send(&mut self.iface)?;
+        Command::VcomhDeselect(VcomhLevel::Auto).send(&mut self.iface)?;
+        Command::AllOn(false).send(&mut self.iface)?;
+        Command::Invert(false).send(&mut self.iface)?;
+        Command::EnableScroll(false).send(&mut self.iface)?;
+        Command::DisplayOn(true).send(&mut self.iface)?;
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Quick fix-up for #9 

* hal::blocking::spi::Transfer wasn't necessary on the SPI implementation, removed it.
* Added an Error associated type to the DisplayInterface trait.
* passed along errors where necessary rather than silencing them.