### PR TITLE
Add outline to docs and deny them in the future

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -6,6 +6,3 @@ rustflags = [
   "-Z", "linker-flavor=ld",
   "-Z", "thinlto=no",
 ]
-
-[build]
-target = "thumbv7m-none-eabi"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -14,13 +14,15 @@ pub struct Builder {
 }
 
 impl Builder {
-    /// Create new builder for default size of 128 x 32 pixels.
+    /// Create new builder for default size of 128 x 64 pixels.
     pub fn new() -> Self {
-        Builder::with_size(DisplaySize::Display128x32)
+        Self {
+            display_size: DisplaySize::Display128x64,
+        }
     }
 
     /// Create new builder for a specified size.
-    pub fn with_size(display_size: DisplaySize) -> Self {
+    pub fn with_size(&self, display_size: DisplaySize) -> Self {
         Self { display_size }
     }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,3 +1,5 @@
+//! Interface factory
+
 use hal;
 use hal::digital::OutputPin;
 
@@ -5,22 +7,24 @@ use super::displaysize::DisplaySize;
 use super::interface::{I2cInterface, SpiInterface};
 use super::SSD1306;
 
+/// Communication interface factory
 #[derive(Clone, Copy)]
 pub struct Builder {
     display_size: DisplaySize,
 }
 
 impl Builder {
+    /// Create new builder for default size of 128 x 32 pixels.
     pub fn new() -> Self {
-        Self {
-            display_size: DisplaySize::Display128x64,
-        }
+        Builder::with_size(DisplaySize::Display128x32)
     }
 
-    pub fn with_size(&self, display_size: DisplaySize) -> Self {
+    /// Create new builder for a specified size.
+    pub fn with_size(display_size: DisplaySize) -> Self {
         Self { display_size }
     }
 
+    /// Create i2c communication interface
     pub fn connect_i2c<I2C>(&self, i2c: I2C) -> SSD1306<I2cInterface<I2C>>
     where
         I2C: hal::blocking::i2c::Write,
@@ -28,6 +32,7 @@ impl Builder {
         SSD1306::new(I2cInterface::new(i2c), self.display_size)
     }
 
+    /// Create spi communication interface
     pub fn connect_spi<SPI, DC>(&self, spi: SPI, dc: DC) -> SSD1306<SpiInterface<SPI, DC>>
     where
         SPI: hal::blocking::spi::Transfer<u8> + hal::blocking::spi::Write<u8>,

--- a/src/displaysize.rs
+++ b/src/displaysize.rs
@@ -1,12 +1,18 @@
-// TODO: Prelude
+//! Display size
+
+/// Display size enumeration
 #[derive(Clone, Copy)]
 pub enum DisplaySize {
+    /// 128 by 64 pixels
     Display128x64,
+    /// 128 by 32 pixels
     Display128x32,
+    /// 96 by 16 pixels
     Display96x16,
 }
 
 impl DisplaySize {
+    /// Get integral dimensions from DisplaySize
     // TODO: Use whatever vec2 impl I decide to use here
     pub fn dimensions(&self) -> (u8, u8) {
         match *self {

--- a/src/interface/i2c.rs
+++ b/src/interface/i2c.rs
@@ -1,7 +1,10 @@
+//! SSD1306 I2C Interface
+
 use hal;
 
 use super::DisplayInterface;
 
+/// SSD1306 I2C communication interface
 pub struct I2cInterface<I2C> {
     i2c: I2C,
 }
@@ -10,6 +13,7 @@ impl<I2C> I2cInterface<I2C>
 where
     I2C: hal::blocking::i2c::Write,
 {
+    /// Create new SSD1306 I2C interface
     pub fn new(i2c: I2C) -> Self {
         Self { i2c }
     }

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -1,10 +1,16 @@
+//! SSD1306 Communication Interface
+
 pub mod i2c;
 pub mod spi;
 
+/// A method of communicating with SSD1306
 pub trait DisplayInterface {
+    /// Communication error.
     type Error;
 
+    /// Send a command to display.
     fn send_command(&mut self, cmd: u8) -> Result<(), Self::Error>;
+    /// Send data to display.
     fn send_data(&mut self, buf: &[u8]) -> Result<(), Self::Error>;
 }
 

--- a/src/interface/spi.rs
+++ b/src/interface/spi.rs
@@ -1,8 +1,13 @@
+//! SSD1306 SPI interface
+
 use hal;
 use hal::digital::OutputPin;
 
 use super::DisplayInterface;
 
+/// SPI display interface.
+///
+/// This combines the SPI peripheral and a data/command pin
 pub struct SpiInterface<SPI, DC> {
     spi: SPI,
     dc: DC,
@@ -13,6 +18,7 @@ where
     SPI: hal::blocking::spi::Write<u8>,
     DC: OutputPin,
 {
+    /// Create new SPI interface for communciation with SSD1306
     pub fn new(spi: SPI, dc: DC) -> Self {
         Self { spi, dc }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,13 @@
 // #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 #![deny(warnings)]
+#![deny(missing_copy_implementations)]
+#![deny(trivial_casts)]
+#![deny(trivial_numeric_casts)]
+#![deny(unsafe_code)]
+#![deny(unstable_features)]
+#![deny(unused_import_braces)]
+#![deny(unused_qualifications)]
 
 #[cfg(feature = "graphics")]
 extern crate embedded_graphics;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,10 @@
+//! SSD1306 OLED display driver
+
 #![no_std]
 // TODO: Docs
-// #![deny(missing_docs)]
 // #![deny(missing_debug_implementations)]
-#![deny(missing_copy_implementations)]
-#![deny(trivial_casts)]
-#![deny(trivial_numeric_casts)]
-#![deny(unsafe_code)]
-#![deny(unstable_features)]
-#![deny(unused_import_braces)]
-#![deny(unused_qualifications)]
+#![deny(missing_docs)]
+#![deny(warnings)]
 
 #[cfg(feature = "graphics")]
 extern crate embedded_graphics;
@@ -27,6 +23,7 @@ use hal::blocking::delay::DelayMs;
 use hal::digital::OutputPin;
 use interface::DisplayInterface;
 
+/// SSD1306
 pub struct SSD1306<DI> {
     iface: DI,
     buffer: [u8; 1024],
@@ -37,6 +34,7 @@ impl<DI> SSD1306<DI>
 where
     DI: DisplayInterface,
 {
+    /// Create new SSD1306 instance
     pub fn new(iface: DI, display_size: DisplaySize) -> SSD1306<DI> {
         SSD1306 {
             iface,
@@ -63,6 +61,7 @@ where
         rst.set_high();
     }
 
+    /// Write out data to display
     pub fn flush(&mut self) -> Result<(), DI::Error> {
         let (display_width, display_height) = self.display_size.dimensions();
 
@@ -76,6 +75,7 @@ where
         }
     }
 
+    /// Turn a pixel on or off
     pub fn set_pixel(&mut self, x: u32, y: u32, value: u8) {
         let (display_width, _) = self.display_size.dimensions();
 
@@ -90,6 +90,7 @@ where
     }
 
     // Display is set up in column mode, i.e. a byte walks down a column of 8 pixels from column 0 on the left, to column _n_ on the right
+    /// Initialize display in column mode.
     pub fn init(&mut self) -> Result<(), DI::Error> {
         let (_, display_height) = self.display_size.dimensions();
 


### PR DESCRIPTION
Start to #8. This *DOES NOT* close that issue, the docs need to be more thoroughly fleshed out, but it allows us to enable the lint going forward and enforce good (developer) behavior.