### PR TITLE
Un-hard-code I2C address

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -11,6 +11,7 @@ use super::SSD1306;
 #[derive(Clone, Copy)]
 pub struct Builder {
     display_size: DisplaySize,
+    i2c_addr: u8,
 }
 
 impl Builder {
@@ -18,12 +19,24 @@ impl Builder {
     pub fn new() -> Self {
         Self {
             display_size: DisplaySize::Display128x64,
+            i2c_addr: 0x3c,
         }
     }
 
     /// Create new builder for a specified size.
     pub fn with_size(&self, display_size: DisplaySize) -> Self {
-        Self { display_size }
+        Self {
+            display_size,
+            ..*self
+        }
+    }
+
+    /// Set the I2C address to use. Defaults to 0x3C which seems to be the most common address.
+    /// The other address specified in the datasheet is 0x3D.
+    ///
+    /// Ignored when using SPI interface
+    pub fn with_i2c_addr(&self, i2c_addr: u8) -> Self {
+        Self { i2c_addr, ..*self }
     }
 
     /// Create i2c communication interface
@@ -31,7 +44,7 @@ impl Builder {
     where
         I2C: hal::blocking::i2c::Write,
     {
-        SSD1306::new(I2cInterface::new(i2c), self.display_size)
+        SSD1306::new(I2cInterface::new(i2c, self.i2c_addr), self.display_size)
     }
 
     /// Create spi communication interface

--- a/src/interface/i2c.rs
+++ b/src/interface/i2c.rs
@@ -7,6 +7,7 @@ use super::DisplayInterface;
 /// SSD1306 I2C communication interface
 pub struct I2cInterface<I2C> {
     i2c: I2C,
+    addr: u8,
 }
 
 impl<I2C> I2cInterface<I2C>
@@ -14,8 +15,8 @@ where
     I2C: hal::blocking::i2c::Write,
 {
     /// Create new SSD1306 I2C interface
-    pub fn new(i2c: I2C) -> Self {
-        Self { i2c }
+    pub fn new(i2c: I2C, addr: u8) -> Self {
+        Self { i2c, addr }
     }
 }
 
@@ -26,7 +27,7 @@ where
     type Error = I2C::Error;
 
     fn send_command(&mut self, cmd: u8) -> Result<(), I2C::Error> {
-        self.i2c.write(0x3c, &[0, cmd])?;
+        self.i2c.write(self.addr, &[0, cmd])?;
 
         Ok(())
     }
@@ -47,7 +48,7 @@ where
             for (i, byte) in chunk.iter().enumerate() {
                 writebuf[i + 1] = *byte;
             }
-            self.i2c.write(0x3C, &writebuf[..1 + chunk.len()])?;
+            self.i2c.write(self.addr, &writebuf[..1 + chunk.len()])?;
         }
 
         Ok(())


### PR DESCRIPTION
Section 8.1.5) a) in the datasheet states that the display address can be 0x3C or 0x3D, chosen with the D/C pin.

It can now be configured using the `.with_i2c_addr()` method on the `Builder`. Example:

```rust
let mut disp = Builder::new()
        .with_size(DisplaySize::Display128x32)
        .with_i2c_addr(0x3d)
        .connect_i2c(i2c);
```

Closes #12.

@scowcron This is where the builder pattern starts making sense to me; it feels more Rustic to chain a bunch of calls together to configure the object. Feels a bit like chaining iterator methods.