### PR TITLE
Display rotation

### DIFF
--- a/examples/rotation_i2c.rs
+++ b/examples/rotation_i2c.rs
@@ -1,4 +1,4 @@
-//! Draw a 1 bit per pixel black and white image. On a 128x64 SSD1306 display over I2C.
+//! Draw the Rust logo centered on a 90 degree rotated 128x64px display
 //!
 //! Image was created with ImageMagick:
 //!
@@ -6,7 +6,7 @@
 //! convert rust.png -depth 1 gray:rust.raw
 //! ```
 //!
-//! Run on a Blue Pill with `xargo run --example image_i2c --features graphics`
+//! Run on a Blue Pill with `xargo run --target thumbv7m-none-eabi --example image_i2c --features graphics`
 
 #![no_std]
 
@@ -56,7 +56,14 @@ fn main() {
     disp.init();
     disp.flush();
 
-    let im = Image1BPP::new(include_bytes!("./rust.raw"), 64, 64, (32, 0));
+    let (w, h) = disp.get_dimensions();
+
+    let im = Image1BPP::new(
+        include_bytes!("./rust.raw"),
+        64,
+        64,
+        (w as u32 / 2 - 64 / 2, h as u32 / 2 - 64 / 2),
+    );
 
     disp.draw(im.into_iter());
 

--- a/examples/rotation_i2c.rs
+++ b/examples/rotation_i2c.rs
@@ -51,7 +51,7 @@ fn main() {
     );
 
     let mut disp = Builder::new()
-        .with_rotation(DisplayRotation::Rotate180)
+        .with_rotation(DisplayRotation::Rotate90)
         .connect_i2c(i2c);
     disp.init();
     disp.flush();

--- a/examples/rotation_i2c.rs
+++ b/examples/rotation_i2c.rs
@@ -1,0 +1,64 @@
+//! Draw a 1 bit per pixel black and white image. On a 128x64 SSD1306 display over I2C.
+//!
+//! Image was created with ImageMagick:
+//!
+//! ```bash
+//! convert rust.png -depth 1 gray:rust.raw
+//! ```
+//!
+//! Run on a Blue Pill with `xargo run --example image_i2c --features graphics`
+
+#![no_std]
+
+extern crate cortex_m;
+extern crate embedded_graphics;
+extern crate embedded_hal as hal;
+extern crate ssd1306;
+extern crate stm32f103xx_hal as blue_pill;
+
+use blue_pill::i2c::{DutyCycle, I2c, Mode};
+use blue_pill::prelude::*;
+use embedded_graphics::Drawing;
+use ssd1306::Builder;
+use ssd1306::displayrotation::DisplayRotation;
+use embedded_graphics::image::{Image, Image1BPP};
+
+fn main() {
+    let dp = blue_pill::stm32f103xx::Peripherals::take().unwrap();
+
+    let mut flash = dp.FLASH.constrain();
+    let mut rcc = dp.RCC.constrain();
+
+    let clocks = rcc.cfgr.freeze(&mut flash.acr);
+
+    let mut afio = dp.AFIO.constrain(&mut rcc.apb2);
+
+    let mut gpiob = dp.GPIOB.split(&mut rcc.apb2);
+
+    let scl = gpiob.pb8.into_alternate_open_drain(&mut gpiob.crh);
+    let sda = gpiob.pb9.into_alternate_open_drain(&mut gpiob.crh);
+
+    let i2c = I2c::i2c1(
+        dp.I2C1,
+        (scl, sda),
+        &mut afio.mapr,
+        Mode::Fast {
+            frequency: 400_000,
+            duty_cycle: DutyCycle::Ratio1to1,
+        },
+        clocks,
+        &mut rcc.apb1,
+    );
+
+    let mut disp = Builder::new()
+        .with_rotation(DisplayRotation::Rotate180)
+        .connect_i2c(i2c);
+    disp.init();
+    disp.flush();
+
+    let im = Image1BPP::new(include_bytes!("./rust.raw"), 64, 64, (32, 0));
+
+    disp.draw(im.into_iter());
+
+    disp.flush();
+}

--- a/examples/rotation_i2c.rs
+++ b/examples/rotation_i2c.rs
@@ -53,8 +53,8 @@ fn main() {
     let mut disp = Builder::new()
         .with_rotation(DisplayRotation::Rotate90)
         .connect_i2c(i2c);
-    disp.init();
-    disp.flush();
+    disp.init().unwrap();
+    disp.flush().unwrap();
 
     let (w, h) = disp.get_dimensions();
 
@@ -67,5 +67,5 @@ fn main() {
 
     disp.draw(im.into_iter());
 
-    disp.flush();
+    disp.flush().unwrap();
 }

--- a/examples/rotation_i2c.rs
+++ b/examples/rotation_i2c.rs
@@ -51,10 +51,16 @@ fn main() {
     );
 
     let mut disp = Builder::new()
+        // Set initial rotation at 90 degrees clockwise
         .with_rotation(DisplayRotation::Rotate90)
         .connect_i2c(i2c);
+
     disp.init().unwrap();
     disp.flush().unwrap();
+
+    // Contrived example to test builder and instance methods. Sets rotation to 270 degress
+    // or 90 degress counterclockwise
+    disp.set_rotation(DisplayRotation::Rotate270).unwrap();
 
     let (w, h) = disp.get_dimensions();
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -4,6 +4,7 @@ use hal;
 use hal::digital::OutputPin;
 
 use super::displaysize::DisplaySize;
+use super::displayrotation::DisplayRotation;
 use super::interface::{I2cInterface, SpiInterface};
 use super::SSD1306;
 
@@ -11,6 +12,7 @@ use super::SSD1306;
 #[derive(Clone, Copy)]
 pub struct Builder {
     display_size: DisplaySize,
+    rotation: DisplayRotation,
     i2c_addr: u8,
 }
 
@@ -19,6 +21,7 @@ impl Builder {
     pub fn new() -> Self {
         Self {
             display_size: DisplaySize::Display128x64,
+            rotation: DisplayRotation::Rotate0,
             i2c_addr: 0x3c,
         }
     }
@@ -39,12 +42,21 @@ impl Builder {
         Self { i2c_addr, ..*self }
     }
 
+    /// Set the rotation of the display to one of four values. Defaults to no rotation
+    pub fn with_rotation(&self, rotation: DisplayRotation) -> Self {
+        Self { rotation, ..*self }
+    }
+
     /// Create i2c communication interface
     pub fn connect_i2c<I2C>(&self, i2c: I2C) -> SSD1306<I2cInterface<I2C>>
     where
         I2C: hal::blocking::i2c::Write,
     {
-        SSD1306::new(I2cInterface::new(i2c, self.i2c_addr), self.display_size)
+        SSD1306::new(
+            I2cInterface::new(i2c, self.i2c_addr),
+            self.display_size,
+            self.rotation,
+        )
     }
 
     /// Create spi communication interface
@@ -53,6 +65,6 @@ impl Builder {
         SPI: hal::blocking::spi::Transfer<u8> + hal::blocking::spi::Write<u8>,
         DC: OutputPin,
     {
-        SSD1306::new(SpiInterface::new(spi, dc), self.display_size)
+        SSD1306::new(SpiInterface::new(spi, dc), self.display_size, self.rotation)
     }
 }

--- a/src/displayrotation.rs
+++ b/src/displayrotation.rs
@@ -1,0 +1,14 @@
+//! Display rotation
+
+/// Display rotation enumeration
+#[derive(Clone, Copy)]
+pub enum DisplayRotation {
+    /// No rotation, normal display
+    Rotate0,
+    /// Rotate by 90 degress clockwise
+    Rotate90,
+    /// Rotate by 180 degress (flip)
+    Rotate180,
+    /// Rotate the display by 270 degress
+    Rotate270,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,20 +149,20 @@ where
 
         match self.display_rotation {
             DisplayRotation::Rotate0 => {
-                Command::SegmentRemap(false).send(&mut self.iface)?;
-                Command::ReverseComDir(false).send(&mut self.iface)?;
+                Command::SegmentRemap(true).send(&mut self.iface)?;
+                Command::ReverseComDir(true).send(&mut self.iface)?;
             }
             DisplayRotation::Rotate90 => {
-                Command::SegmentRemap(true).send(&mut self.iface)?;
-                Command::ReverseComDir(false).send(&mut self.iface)?;
-            }
-            DisplayRotation::Rotate180 => {
-                Command::SegmentRemap(true).send(&mut self.iface)?;
-                Command::ReverseComDir(true).send(&mut self.iface)?;
-            }
-            DisplayRotation::Rotate270 => {
                 Command::SegmentRemap(false).send(&mut self.iface)?;
                 Command::ReverseComDir(true).send(&mut self.iface)?;
+            }
+            DisplayRotation::Rotate180 => {
+                Command::SegmentRemap(false).send(&mut self.iface)?;
+                Command::ReverseComDir(false).send(&mut self.iface)?;
+            }
+            DisplayRotation::Rotate270 => {
+                Command::SegmentRemap(true).send(&mut self.iface)?;
+                Command::ReverseComDir(false).send(&mut self.iface)?;
             }
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,6 +150,17 @@ where
 
         Ok(())
     }
+
+    /// Get display dimensions, taking into account the current rotation of the display
+    // TODO: Replace (u8, u8) with a dimensioney type for consistency
+    pub fn get_dimensions(&self) -> (u8, u8) {
+        let (w, h) = self.display_size.dimensions();
+
+        match self.display_rotation {
+            DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => (w, h),
+            DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => (h, w),
+        }
+    }
 }
 
 #[cfg(feature = "graphics")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,6 +147,26 @@ where
         Command::ChargePump(true).send(&mut self.iface)?;
         Command::AddressMode(AddrMode::Horizontal).send(&mut self.iface)?;
 
+        self.configure_rotation()?;
+
+        match self.display_size {
+            DisplaySize::Display128x32 => Command::ComPinConfig(false, false).send(&mut self.iface),
+            DisplaySize::Display128x64 => Command::ComPinConfig(true, false).send(&mut self.iface),
+            DisplaySize::Display96x16 => Command::ComPinConfig(false, false).send(&mut self.iface),
+        }?;
+
+        Command::Contrast(0x8F).send(&mut self.iface)?;
+        Command::PreChargePeriod(0x1, 0xF).send(&mut self.iface)?;
+        Command::VcomhDeselect(VcomhLevel::Auto).send(&mut self.iface)?;
+        Command::AllOn(false).send(&mut self.iface)?;
+        Command::Invert(false).send(&mut self.iface)?;
+        Command::EnableScroll(false).send(&mut self.iface)?;
+        Command::DisplayOn(true).send(&mut self.iface)?;
+
+        Ok(())
+    }
+
+    fn configure_rotation(&mut self) -> Result<(), DI::Error> {
         match self.display_rotation {
             DisplayRotation::Rotate0 => {
                 Command::SegmentRemap(true).send(&mut self.iface)?;
@@ -166,20 +186,6 @@ where
             }
         };
 
-        match self.display_size {
-            DisplaySize::Display128x32 => Command::ComPinConfig(false, false).send(&mut self.iface),
-            DisplaySize::Display128x64 => Command::ComPinConfig(true, false).send(&mut self.iface),
-            DisplaySize::Display96x16 => Command::ComPinConfig(false, false).send(&mut self.iface),
-        }?;
-
-        Command::Contrast(0x8F).send(&mut self.iface)?;
-        Command::PreChargePeriod(0x1, 0xF).send(&mut self.iface)?;
-        Command::VcomhDeselect(VcomhLevel::Auto).send(&mut self.iface)?;
-        Command::AllOn(false).send(&mut self.iface)?;
-        Command::Invert(false).send(&mut self.iface)?;
-        Command::EnableScroll(false).send(&mut self.iface)?;
-        Command::DisplayOn(true).send(&mut self.iface)?;
-
         Ok(())
     }
 
@@ -192,6 +198,13 @@ where
             DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => (w, h),
             DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => (h, w),
         }
+    }
+
+    /// Set the display rotation
+    pub fn set_rotation(&mut self, rot: DisplayRotation) -> Result<(), DI::Error> {
+        self.display_rotation = rot;
+
+        self.configure_rotation()
     }
 }
 


### PR DESCRIPTION
Adds 0, 90, 180 and 270 degree rotations to the display. Usable like so:

```rust
let mut disp = Builder::new()
    .with_rotation(DisplayRotation::Rotate90)
    .connect_i2c(i2c);
```

Also adds the `get_dimensions()` method so consumers of this driver can position stuff relative to the display size.