### PR TITLE
Turn graphics feature on by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,5 +44,5 @@ debug = true
 lto = true
 
 [features]
-default = []
+default = ["graphics"]
 graphics = ["embedded-graphics"]


### PR DESCRIPTION
As raised by @therealprof and @chocol4te in #30, it makes sense to have
these features enabled by default, but disable-able if someone _really_
needs to. The compiler will optimise it all out anyway.