### PR TITLE
Lock embedded_graphics to commit hash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ embedded-hal = "0.1.2"
 
 [dependencies.embedded-graphics]
 git = "https://github.com/jamwaffles/embedded-graphics.git"
-version = "*"
+rev = "b9794421b74dc810979e9d4191718917f715575a"
 optional = true
 
 [dev-dependencies]

--- a/examples/image_i2c.rs
+++ b/examples/image_i2c.rs
@@ -19,8 +19,9 @@ extern crate stm32f103xx_hal as blue_pill;
 use blue_pill::i2c::{DutyCycle, I2c, Mode};
 use blue_pill::prelude::*;
 use embedded_graphics::Drawing;
-use ssd1306::Builder;
 use embedded_graphics::image::{Image, Image1BPP};
+use embedded_graphics::transform::Transform;
+use ssd1306::Builder;
 
 fn main() {
     let dp = blue_pill::stm32f103xx::Peripherals::take().unwrap();
@@ -53,7 +54,7 @@ fn main() {
     disp.init().unwrap();
     disp.flush().unwrap();
 
-    let im = Image1BPP::new(include_bytes!("./rust.raw"), 64, 64, (32, 0));
+    let im = Image1BPP::new(include_bytes!("./rust.raw"), 64, 64).translate((32, 0));
 
     disp.draw(im.into_iter());
 

--- a/examples/rotation_i2c.rs
+++ b/examples/rotation_i2c.rs
@@ -19,9 +19,10 @@ extern crate stm32f103xx_hal as blue_pill;
 use blue_pill::i2c::{DutyCycle, I2c, Mode};
 use blue_pill::prelude::*;
 use embedded_graphics::Drawing;
+use embedded_graphics::image::{Image, Image1BPP};
+use embedded_graphics::transform::Transform;
 use ssd1306::Builder;
 use ssd1306::displayrotation::DisplayRotation;
-use embedded_graphics::image::{Image, Image1BPP};
 
 fn main() {
     let dp = blue_pill::stm32f103xx::Peripherals::take().unwrap();
@@ -64,12 +65,8 @@ fn main() {
 
     let (w, h) = disp.get_dimensions();
 
-    let im = Image1BPP::new(
-        include_bytes!("./rust.raw"),
-        64,
-        64,
-        (w as u32 / 2 - 64 / 2, h as u32 / 2 - 64 / 2),
-    );
+    let im = Image1BPP::new(include_bytes!("./rust.raw"), 64, 64)
+        .translate((w as u32 / 2 - 64 / 2, h as u32 / 2 - 64 / 2));
 
     disp.draw(im.into_iter());
 

--- a/examples/text_i2c.rs
+++ b/examples/text_i2c.rs
@@ -14,8 +14,9 @@ extern crate stm32f103xx_hal as blue_pill;
 use blue_pill::i2c::{DutyCycle, I2c, Mode};
 use blue_pill::prelude::*;
 use embedded_graphics::Drawing;
-use ssd1306::Builder;
 use embedded_graphics::fonts::{Font, Font6x8};
+use embedded_graphics::transform::Transform;
+use ssd1306::Builder;
 
 fn main() {
     let dp = blue_pill::stm32f103xx::Peripherals::take().unwrap();
@@ -48,8 +49,12 @@ fn main() {
     disp.init().unwrap();
     disp.flush().unwrap();
 
-    disp.draw(Font6x8::render_str("Hello world!", (0, 0)).into_iter());
-    disp.draw(Font6x8::render_str("Hello Rust!", (0, 16)).into_iter());
+    disp.draw(Font6x8::render_str("Hello world!").into_iter());
+    disp.draw(
+        Font6x8::render_str("Hello Rust!")
+            .translate((0, 16))
+            .into_iter(),
+    );
 
     disp.flush().unwrap();
 }


### PR DESCRIPTION
This should've been done in the first place really. By locking the dependency at a hash, breaking changes shouldn't leak to this crate. Also fixes all the examples.

Closes jamwaffles/embedded-graphics#9