### PR TITLE
Features/refactorcommands

### DIFF
--- a/src/mode/graphics.rs
+++ b/src/mode/graphics.rs
@@ -67,12 +67,12 @@ where
         // Ensure the display buffer is at the origin of the display before we send the full frame
         // to prevent accidental offsets
         let (display_width, display_height) = display_size.dimensions();
-        self.properties.set_render_area((0, display_width), (0, display_height))?;
+        self.properties.set_draw_area((0, display_width), (0, display_height))?;
 
         match display_size {
-            DisplaySize::Display128x64 => self.properties.render(&self.buffer),
-            DisplaySize::Display128x32 => self.properties.render(&self.buffer[0..512]),
-            DisplaySize::Display96x16 => self.properties.render(&self.buffer[0..192]),
+            DisplaySize::Display128x64 => self.properties.draw(&self.buffer),
+            DisplaySize::Display128x32 => self.properties.draw(&self.buffer[0..512]),
+            DisplaySize::Display96x16 => self.properties.draw(&self.buffer[0..192]),
         }
     }
 

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -68,14 +68,14 @@ where
     }
 
     /// Set the area on the display the data should be rendered onto
-    pub fn set_render_area(&mut self, start: (u8, u8), end: (u8, u8)) -> Result<(), DI::Error> {
+    pub fn set_render_area(&mut self, start: (u8, u8), end: (u8, u8)) -> Result<(), ()> {
         Command::ColumnAddress(start.0, start.1 - 1).send(&mut self.iface)?;
         Command::PageAddress(start.1.into(), (end.1 - 1).into()).send(&mut self.iface)?;
         Ok(())
     }
 
     /// Render data onto the display
-    pub fn render(&mut self, buffer: &[u8]) -> Result<(), DI::Error> {
+    pub fn render(&mut self, buffer: &[u8]) -> Result<(), ()> {
         self.iface.send_data(&buffer)?;
         Ok(())
     }

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -67,15 +67,19 @@ where
         Ok(())
     }
 
-    /// Set the area on the display the data should be rendered onto
-    pub fn set_render_area(&mut self, start: (u8, u8), end: (u8, u8)) -> Result<(), ()> {
+    /// Set the position in the framebuffer of the display where any sent data should be
+    /// drawn. This method can be used for changing the affected area on the screen as well
+    /// as (re-)setting the start point of the next `draw` call.
+    pub fn set_draw_area(&mut self, start: (u8, u8), end: (u8, u8)) -> Result<(), ()> {
         Command::ColumnAddress(start.0, start.1 - 1).send(&mut self.iface)?;
         Command::PageAddress(start.1.into(), (end.1 - 1).into()).send(&mut self.iface)?;
         Ok(())
     }
 
-    /// Render data onto the display
-    pub fn render(&mut self, buffer: &[u8]) -> Result<(), ()> {
+    /// Send the data to the display for drawing at the current position in the framebuffer
+    /// and advance the position accordingly. Cf. `set_draw_area` to modify the affected area by
+    /// this method.
+    pub fn draw(&mut self, buffer: &[u8]) -> Result<(), ()> {
         self.iface.send_data(&buffer)?;
         Ok(())
     }

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -67,9 +67,17 @@ where
         Ok(())
     }
 
-    /// Borrow configured interface for raw communication
-    pub fn borrow_iface_mut(&mut self) -> &mut DI {
-        &mut self.iface
+    /// Set the area on the display the data should be rendered onto
+    pub fn set_render_area(&mut self, start: (u8, u8), end: (u8, u8)) -> Result<(), DI::Error> {
+        Command::ColumnAddress(start.0, start.1 - 1).send(&mut self.iface)?;
+        Command::PageAddress(start.1.into(), (end.1 - 1).into()).send(&mut self.iface)?;
+        Ok(())
+    }
+
+    /// Render data onto the display
+    pub fn render(&mut self, buffer: &[u8]) -> Result<(), DI::Error> {
+        self.iface.send_data(&buffer)?;
+        Ok(())
     }
 
     /// Get the configured display size


### PR DESCRIPTION
Probably not the best name in the world. This refactors the direct use of the interface in the graphicsmode to only use methods provided by the `DisplayProperties` and removes the `borrow_iface_mut()`.