### PR TITLE
Features/makeclippyhappy

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -18,6 +18,12 @@ pub struct Builder {
     i2c_addr: u8,
 }
 
+impl Default for Builder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Builder {
     /// Create new builder for default size of 128 x 64 pixels.
     pub fn new() -> Self {
@@ -63,7 +69,11 @@ impl Builder {
     }
 
     /// Create spi communication interface
-    pub fn connect_spi<SPI, DC>(&self, spi: SPI, dc: DC) -> DisplayMode<RawMode<SpiInterface<SPI, DC>>>
+    pub fn connect_spi<SPI, DC>(
+        &self,
+        spi: SPI,
+        dc: DC,
+    ) -> DisplayMode<RawMode<SpiInterface<SPI, DC>>>
     where
         SPI: hal::blocking::spi::Transfer<u8> + hal::blocking::spi::Write<u8>,
         DC: OutputPin,

--- a/src/mode/displaymode.rs
+++ b/src/mode/displaymode.rs
@@ -1,7 +1,5 @@
 //! Abstraction of different operating modes for the SSD1306
 
-use super::raw::RawMode;
-
 use interface::DisplayInterface;
 use properties::DisplayProperties;
 
@@ -18,12 +16,13 @@ pub trait DisplayModeTrait<DI> {
 }
 
 impl<MODE> DisplayMode<MODE> {
-    /// Setup display to run in raw mode
-    pub fn new<DI>(properties: DisplayProperties<DI>) -> DisplayMode<RawMode<DI>>
+    /// Setup display to run in requested mode
+    pub fn new<DI>(properties: DisplayProperties<DI>) -> Self
     where
         DI: DisplayInterface,
+        MODE: DisplayModeTrait<DI>,
     {
-        DisplayMode(RawMode::new(properties))
+        DisplayMode(MODE::new(properties))
     }
 
     /// Change into any mode implementing DisplayModeTrait


### PR DESCRIPTION
NB: plenty of stuff in the examples clippy doesn't like:

```
warning: the operation is ineffective. Consider reducing it to `xoffset`
  --> examples/blinky_i2c.rs:98:20
   |
98 |     disp.set_pixel(xoffset + 0, yoffset + 0, 1);
   |                    ^^^^^^^^^^^
   |
   = note: #[warn(identity_op)] on by default
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.193/index.html#identity_op

warning: the operation is ineffective. Consider reducing it to `yoffset`
  --> examples/blinky_i2c.rs:98:33
   |
98 |     disp.set_pixel(xoffset + 0, yoffset + 0, 1);
   |                                 ^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.193/index.html#identity_op

warning: the operation is ineffective. Consider reducing it to `yoffset`
  --> examples/blinky_i2c.rs:99:33
   |
99 |     disp.set_pixel(xoffset + 1, yoffset + 0, 1);
   |                                 ^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.193/index.html#identity_op

warning: the operation is ineffective. Consider reducing it to `yoffset`
   --> examples/blinky_i2c.rs:100:33
    |
100 |     disp.set_pixel(xoffset + 2, yoffset + 0, 1);
    |                                 ^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.193/index.html#identity_op

warning: the operation is ineffective. Consider reducing it to `yoffset`
   --> examples/blinky_i2c.rs:101:33
    |
101 |     disp.set_pixel(xoffset + 3, yoffset + 0, 1);
    |                                 ^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.193/index.html#identity_op

warning: the operation is ineffective. Consider reducing it to `yoffset`
   --> examples/blinky_i2c.rs:104:33
    |
104 |     disp.set_pixel(xoffset + 3, yoffset + 0, 1);
    |                                 ^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.193/index.html#identity_op

warning: the operation is ineffective. Consider reducing it to `xoffset`
   --> examples/blinky_i2c.rs:110:20
    |
110 |     disp.set_pixel(xoffset + 0, yoffset + 3, 1);
    |                    ^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.193/index.html#identity_op

warning: the operation is ineffective. Consider reducing it to `xoffset`
   --> examples/blinky_i2c.rs:116:20
    |
116 |     disp.set_pixel(xoffset + 0, yoffset + 0, 1);
    |                    ^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.193/index.html#identity_op

warning: the operation is ineffective. Consider reducing it to `yoffset`
   --> examples/blinky_i2c.rs:116:33
    |
116 |     disp.set_pixel(xoffset + 0, yoffset + 0, 1);
    |                                 ^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.193/index.html#identity_op

warning: the operation is ineffective. Consider reducing it to `xoffset`
   --> examples/blinky_i2c.rs:117:20
    |
117 |     disp.set_pixel(xoffset + 0, yoffset + 1, 1);
    |                    ^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.193/index.html#identity_op

warning: the operation is ineffective. Consider reducing it to `xoffset`
   --> examples/blinky_i2c.rs:118:20
    |
118 |     disp.set_pixel(xoffset + 0, yoffset + 2, 1);
    |                    ^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.193/index.html#identity_op

warning: the operation is ineffective. Consider reducing it to `xoffset`
   --> examples/blinky_i2c.rs:119:20
    |
119 |     disp.set_pixel(xoffset + 0, yoffset + 3, 1);
    |                    ^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.193/index.html#identity_op

warning: this argument is passed by value, but not consumed in the function body
   --> examples/blinky_i2c.rs:122:32
    |
122 | fn idle(_t: &mut Threshold, r: idle::Resources) -> ! {
    |                                ^^^^^^^^^^^^^^^ help: consider taking a reference instead: `&idle::Resources`
    |
    = note: #[warn(needless_pass_by_value)] on by default
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.193/index.html#needless_pass_by_value

warning: you seem to be trying to match on a boolean expression
   --> examples/blinky_i2c.rs:129:9
    |
129 | /         match *state {
130 | |             true => draw_square(&mut disp, 0, 0),
131 | |             false => draw_square(&mut disp, 6, 0),
132 | |         }
    | |_________^ help: consider using an if/else expression: `if *state { draw_square(&mut disp, 0, 0) } else { draw_square(&mut disp, 6, 0) }`
    |
    = note: #[warn(match_bool)] on by default
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.193/index.html#match_bool

warning: the operation is ineffective. Consider reducing it to `xoffset`
   --> examples/blinky.rs:124:20
    |
124 |     disp.set_pixel(xoffset + 0, yoffset + 0, 1);
    |                    ^^^^^^^^^^^
    |
    = note: #[warn(identity_op)] on by default
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.193/index.html#identity_op

warning: the operation is ineffective. Consider reducing it to `yoffset`
   --> examples/blinky.rs:124:33
    |
124 |     disp.set_pixel(xoffset + 0, yoffset + 0, 1);
    |                                 ^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.193/index.html#identity_op

warning: the operation is ineffective. Consider reducing it to `yoffset`
   --> examples/blinky.rs:125:33
    |
125 |     disp.set_pixel(xoffset + 1, yoffset + 0, 1);
    |                                 ^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.193/index.html#identity_op

warning: the operation is ineffective. Consider reducing it to `yoffset`
   --> examples/blinky.rs:126:33
    |
126 |     disp.set_pixel(xoffset + 2, yoffset + 0, 1);
    |                                 ^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.193/index.html#identity_op

warning: the operation is ineffective. Consider reducing it to `yoffset`
   --> examples/blinky.rs:127:33
    |
127 |     disp.set_pixel(xoffset + 3, yoffset + 0, 1);
    |                                 ^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.193/index.html#identity_op

warning: the operation is ineffective. Consider reducing it to `yoffset`
   --> examples/blinky.rs:130:33
    |
130 |     disp.set_pixel(xoffset + 3, yoffset + 0, 1);
    |                                 ^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.193/index.html#identity_op

warning: the operation is ineffective. Consider reducing it to `xoffset`
   --> examples/blinky.rs:136:20
    |
136 |     disp.set_pixel(xoffset + 0, yoffset + 3, 1);
    |                    ^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.193/index.html#identity_op

warning: the operation is ineffective. Consider reducing it to `xoffset`
   --> examples/blinky.rs:142:20
    |
142 |     disp.set_pixel(xoffset + 0, yoffset + 0, 1);
    |                    ^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.193/index.html#identity_op

warning: the operation is ineffective. Consider reducing it to `yoffset`
   --> examples/blinky.rs:142:33
    |
142 |     disp.set_pixel(xoffset + 0, yoffset + 0, 1);
    |                                 ^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.193/index.html#identity_op

warning: the operation is ineffective. Consider reducing it to `xoffset`
   --> examples/blinky.rs:143:20
    |
143 |     disp.set_pixel(xoffset + 0, yoffset + 1, 1);
    |                    ^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.193/index.html#identity_op

warning: the operation is ineffective. Consider reducing it to `xoffset`
   --> examples/blinky.rs:144:20
    |
144 |     disp.set_pixel(xoffset + 0, yoffset + 2, 1);
    |                    ^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.193/index.html#identity_op

warning: the operation is ineffective. Consider reducing it to `xoffset`
   --> examples/blinky.rs:145:20
    |
145 |     disp.set_pixel(xoffset + 0, yoffset + 3, 1);
    |                    ^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.193/index.html#identity_op

warning: this argument is passed by value, but not consumed in the function body
   --> examples/blinky.rs:148:32
    |
148 | fn idle(_t: &mut Threshold, r: idle::Resources) -> ! {
    |                                ^^^^^^^^^^^^^^^ help: consider taking a reference instead: `&idle::Resources`
    |
    = note: #[warn(needless_pass_by_value)] on by default
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.193/index.html#needless_pass_by_value

warning: you seem to be trying to match on a boolean expression
   --> examples/blinky.rs:155:9
    |
155 | /         match *state {
156 | |             true => draw_square(&mut disp, 0, 0),
157 | |             false => draw_square(&mut disp, 6, 0),
158 | |         }
    | |_________^ help: consider using an if/else expression: `if *state { draw_square(&mut disp, 0, 0) } else { draw_square(&mut disp, 6, 0) }`
    |
    = note: #[warn(match_bool)] on by default
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.193/index.html#match_bool

warning: casting u8 to u32 may become silently lossy if types change
  --> examples/rotation_i2c.rs:69:21
   |
69 |         .translate((w as u32 / 2 - 64 / 2, h as u32 / 2 - 64 / 2));
   |                     ^^^^^^^^ help: try: `u32::from(w)`
   |
   = note: #[warn(cast_lossless)] on by default
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.193/index.html#cast_lossless

warning: casting u8 to u32 may become silently lossy if types change
  --> examples/rotation_i2c.rs:69:44
   |
69 |         .translate((w as u32 / 2 - 64 / 2, h as u32 / 2 - 64 / 2));
   |                                            ^^^^^^^^ help: try: `u32::from(h)`
   |
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.193/index.html#cast_lossless
```