### PR TITLE
Fix typo in set_draw_area()

### DIFF
--- a/src/mode/graphics.rs
+++ b/src/mode/graphics.rs
@@ -67,7 +67,8 @@ where
         // Ensure the display buffer is at the origin of the display before we send the full frame
         // to prevent accidental offsets
         let (display_width, display_height) = display_size.dimensions();
-        self.properties.set_draw_area((0, display_width), (0, display_height))?;
+        self.properties
+            .set_draw_area((0, 0), (display_width, display_height))?;
 
         match display_size {
             DisplaySize::Display128x64 => self.properties.draw(&self.buffer),


### PR DESCRIPTION
@therealprof None of my stuff was working. I thought I was going insane, turns out it was just a typo in argument order 😂. TerminalMode [does it right](https://github.com/jamwaffles/ssd1306/blob/fix-graphics-addressing/src/mode/terminal.rs#L162).