### PR TITLE
Update to embedded_graphics with prelude

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ embedded-hal = "0.1.2"
 
 [dependencies.embedded-graphics]
 git = "https://github.com/jamwaffles/embedded-graphics.git"
-rev = "dbbd91b604e1526ef8f6ca6a25e9f4d087aea125"
+rev = "c5b8eb36425b172cab7b3d33b045b1ef8f71c3bd"
 optional = true
 
 [dev-dependencies]

--- a/examples/graphics.rs
+++ b/examples/graphics.rs
@@ -14,10 +14,10 @@ extern crate stm32f103xx_hal as blue_pill;
 use blue_pill::delay::Delay;
 use blue_pill::prelude::*;
 use blue_pill::spi::Spi;
-use embedded_graphics::Drawing;
+use embedded_graphics::prelude::*;
 use embedded_graphics::primitives::{Circle, Line, Rect};
 use hal::spi::{Mode, Phase, Polarity};
-use ssd1306::{Builder, mode::GraphicsMode};
+use ssd1306::{mode::GraphicsMode, Builder};
 
 fn main() {
     let cp = cortex_m::Peripherals::take().unwrap();

--- a/examples/graphics_i2c.rs
+++ b/examples/graphics_i2c.rs
@@ -13,9 +13,9 @@ extern crate stm32f103xx_hal as blue_pill;
 
 use blue_pill::i2c::{DutyCycle, I2c, Mode};
 use blue_pill::prelude::*;
-use embedded_graphics::Drawing;
+use embedded_graphics::prelude::*;
 use embedded_graphics::primitives::{Circle, Line, Rect};
-use ssd1306::{Builder, mode::GraphicsMode};
+use ssd1306::{mode::GraphicsMode, Builder};
 
 fn main() {
     let dp = blue_pill::stm32f103xx::Peripherals::take().unwrap();

--- a/examples/graphics_i2c_128x32.rs
+++ b/examples/graphics_i2c_128x32.rs
@@ -14,9 +14,9 @@ extern crate stm32f103xx_hal as blue_pill;
 
 use blue_pill::i2c::{DutyCycle, I2c, Mode};
 use blue_pill::prelude::*;
-use embedded_graphics::Drawing;
+use embedded_graphics::prelude::*;
 use embedded_graphics::primitives::{Circle, Line, Rect};
-use ssd1306::{Builder, DisplaySize, mode::GraphicsMode};
+use ssd1306::{mode::GraphicsMode, Builder, DisplaySize};
 
 fn main() {
     let dp = blue_pill::stm32f103xx::Peripherals::take().unwrap();

--- a/examples/image_i2c.rs
+++ b/examples/image_i2c.rs
@@ -18,10 +18,9 @@ extern crate stm32f103xx_hal as blue_pill;
 
 use blue_pill::i2c::{DutyCycle, I2c, Mode};
 use blue_pill::prelude::*;
-use embedded_graphics::Drawing;
-use embedded_graphics::image::{Image, Image1BPP};
-use embedded_graphics::transform::Transform;
-use ssd1306::{Builder, mode::GraphicsMode};
+use embedded_graphics::image::Image1BPP;
+use embedded_graphics::prelude::*;
+use ssd1306::{mode::GraphicsMode, Builder};
 
 fn main() {
     let dp = blue_pill::stm32f103xx::Peripherals::take().unwrap();

--- a/examples/rotation_i2c.rs
+++ b/examples/rotation_i2c.rs
@@ -18,11 +18,10 @@ extern crate stm32f103xx_hal as blue_pill;
 
 use blue_pill::i2c::{DutyCycle, I2c, Mode};
 use blue_pill::prelude::*;
-use embedded_graphics::Drawing;
-use embedded_graphics::image::{Image, Image1BPP};
-use embedded_graphics::transform::Transform;
+use embedded_graphics::image::Image1BPP;
+use embedded_graphics::prelude::*;
 use ssd1306::displayrotation::DisplayRotation;
-use ssd1306::{Builder, mode::GraphicsMode};
+use ssd1306::{mode::GraphicsMode, Builder};
 
 fn main() {
     let dp = blue_pill::stm32f103xx::Peripherals::take().unwrap();

--- a/examples/terminal_i2c.rs
+++ b/examples/terminal_i2c.rs
@@ -5,15 +5,14 @@
 #![no_std]
 
 extern crate cortex_m;
-extern crate embedded_graphics;
 extern crate embedded_hal as hal;
 extern crate ssd1306;
 extern crate stm32f103xx_hal as blue_pill;
 
 use blue_pill::i2c::{DutyCycle, I2c, Mode};
 use blue_pill::prelude::*;
-use ssd1306::{Builder, mode::TerminalMode};
 use core::fmt::Write;
+use ssd1306::{mode::TerminalMode, Builder};
 
 fn main() {
     let dp = blue_pill::stm32f103xx::Peripherals::take().unwrap();

--- a/examples/text_i2c.rs
+++ b/examples/text_i2c.rs
@@ -13,10 +13,9 @@ extern crate stm32f103xx_hal as blue_pill;
 
 use blue_pill::i2c::{DutyCycle, I2c, Mode};
 use blue_pill::prelude::*;
-use embedded_graphics::Drawing;
-use embedded_graphics::fonts::{Font, Font6x8};
-use embedded_graphics::transform::Transform;
-use ssd1306::{Builder, mode::GraphicsMode};
+use embedded_graphics::fonts::Font6x8;
+use embedded_graphics::prelude::*;
+use ssd1306::{mode::GraphicsMode, Builder};
 
 fn main() {
     let dp = blue_pill::stm32f103xx::Peripherals::take().unwrap();


### PR DESCRIPTION
Embedded graphics got a prelude in jamwaffles/embedded-graphics@c5b8eb36425b172cab7b3d33b045b1ef8f71c3bd. 

This allows us to fix a lot of the import noise for using embedded_graphics. I've also removed the embedded_graphics dependency from your terminal demo @therealprof.

Some rustfmt stuff snuck in as well, mostly item ordering.