### PR TITLE
90/270º TerminalMode rotation docs

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -88,7 +88,9 @@ impl Builder {
         Self { i2c_addr, ..*self }
     }
 
-    /// Set the rotation of the display to one of four values. Defaults to no rotation
+    /// Set the rotation of the display to one of four values. Defaults to no rotation. Note that
+    /// 90º and 270º rotations are not supported by
+    /// [`TerminalMode`](../mode/terminal/struct.TerminalMode.html).
     pub fn with_rotation(&self, rotation: DisplayRotation) -> Self {
         Self { rotation, ..*self }
     }

--- a/src/displayrotation.rs
+++ b/src/displayrotation.rs
@@ -1,7 +1,10 @@
 //! Display rotation
 
 // TODO: Add to prelude
-/// Display rotation
+/// Display rotation.
+///
+/// Note that 90º and 270º rotations are not supported by
+// [`TerminalMode`](../mode/terminal/struct.TerminalMode.html).
 #[derive(Clone, Copy)]
 pub enum DisplayRotation {
     /// No rotation, normal display


### PR DESCRIPTION
Replaces #61, closes #28

Rotation in terminalmode requires [adding unwanted complexity](https://github.com/jamwaffles/ssd1306/pull/61/commits/c1c2a39e30ff6e10d79a335ce18027a4e63c0db2),
which isn't good for TerminalMode which should stay pretty lightweight.
This PR adds some docs telling the user that particular rotations don't
work for TerminalMode.

I'm on the fence about making `set_rotation()` return an `Err()` if the
user tries to set 90/270º rotations. Thoughts?