### PR TITLE
Support embedded-graphics 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ travis-ci = { repository = "jamwaffles/ssd1306", branch = "master" }
 embedded-hal = "0.2.1"
 
 [dependencies.embedded-graphics]
-version = "0.1.1"
+version = "0.3.0"
 optional = true
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ panic-abort = "0.2.0"
 # TODO: Replace with @japaric's HAL once I2C support has landed
 [dev-dependencies.stm32f103xx-hal]
 git = "https://github.com/ilya-epifanov/stm32f103xx-hal.git"
-rev = "7bd945727d381aedfec5761c1463001e8966f85e"
+rev = "d195a5d01789239477f21ff3e8d05659cfc7467a"
 features = ["rt"]
 version = "*"
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ fn main() {
     disp.init().unwrap();
     disp.flush().unwrap();
 
-    let im = Image1BPP::new(include_bytes!("./rust.raw"), 64, 64).translate((32, 0));
+    let im = Image1BPP::new(include_bytes!("./rust.raw"), 64, 64).translate(Coord::new(32, 0));
 
     disp.draw(im.into_iter());
 

--- a/examples/graphics.rs
+++ b/examples/graphics.rs
@@ -78,13 +78,13 @@ fn main() {
     disp.init().unwrap();
     disp.flush().unwrap();
 
-    disp.draw(Line::new((8, 16 + 16), (8 + 16, 16 + 16), 1).into_iter());
-    disp.draw(Line::new((8, 16 + 16), (8 + 8, 16), 1).into_iter());
-    disp.draw(Line::new((8 + 16, 16 + 16), (8 + 8, 16), 1).into_iter());
+    disp.draw(Line::new(Coord::new(8, 16 + 16), Coord::new(8 + 16, 16 + 16), 1.into()).into_iter());
+    disp.draw(Line::new(Coord::new(8, 16 + 16), Coord::new(8 + 8, 16), 1.into()).into_iter());
+    disp.draw(Line::new(Coord::new(8 + 16, 16 + 16), Coord::new(8 + 8, 16), 1.into()).into_iter());
 
-    disp.draw(Rect::new((48, 16), (48 + 16, 16 + 16), 1u8).into_iter());
+    disp.draw(Rect::new(Coord::new(48, 16), Coord::new(48 + 16, 16 + 16), 1u8.into()).into_iter());
 
-    disp.draw(Circle::new((96, 16 + 8), 8, 1u8).into_iter());
+    disp.draw(Circle::new(Coord::new(96, 16 + 8), 8, 1u8.into()).into_iter());
 
     disp.flush().unwrap();
 }

--- a/examples/graphics_i2c.rs
+++ b/examples/graphics_i2c.rs
@@ -62,13 +62,13 @@ fn main() {
     disp.init().unwrap();
     disp.flush().unwrap();
 
-    disp.draw(Line::new((8, 16 + 16), (8 + 16, 16 + 16), 1).into_iter());
-    disp.draw(Line::new((8, 16 + 16), (8 + 8, 16), 1).into_iter());
-    disp.draw(Line::new((8 + 16, 16 + 16), (8 + 8, 16), 1).into_iter());
+    disp.draw(Line::new(Coord::new(8, 16 + 16), Coord::new(8 + 16, 16 + 16), 1.into()).into_iter());
+    disp.draw(Line::new(Coord::new(8, 16 + 16), Coord::new(8 + 8, 16), 1.into()).into_iter());
+    disp.draw(Line::new(Coord::new(8 + 16, 16 + 16), Coord::new(8 + 8, 16), 1.into()).into_iter());
 
-    disp.draw(Rect::new((48, 16), (48 + 16, 16 + 16), 1u8).into_iter());
+    disp.draw(Rect::new(Coord::new(48, 16), Coord::new(48 + 16, 16 + 16), 1u8.into()).into_iter());
 
-    disp.draw(Circle::new((96, 16 + 8), 8, 1u8).into_iter());
+    disp.draw(Circle::new(Coord::new(96, 16 + 8), 8, 1u8.into()).into_iter());
 
     disp.flush().unwrap();
 }

--- a/examples/graphics_i2c_128x32.rs
+++ b/examples/graphics_i2c_128x32.rs
@@ -57,13 +57,13 @@ fn main() {
 
     let yoffset = 8;
 
-    disp.draw(Line::new((8, 16 + yoffset), (8 + 16, 16 + yoffset), 1).into_iter());
-    disp.draw(Line::new((8, 16 + yoffset), (8 + 8, yoffset), 1).into_iter());
-    disp.draw(Line::new((8 + 16, 16 + yoffset), (8 + 8, yoffset), 1).into_iter());
+    disp.draw(Line::new(Coord::new(8, 16 + yoffset), Coord::new(8 + 16, 16 + yoffset), 1.into()).into_iter());
+    disp.draw(Line::new(Coord::new(8, 16 + yoffset), Coord::new(8 + 8, yoffset), 1.into()).into_iter());
+    disp.draw(Line::new(Coord::new(8 + 16, 16 + yoffset), Coord::new(8 + 8, yoffset), 1.into()).into_iter());
 
-    disp.draw(Rect::new((48, yoffset), (48 + 16, 16 + yoffset), 1u8).into_iter());
+    disp.draw(Rect::new(Coord::new(48, yoffset), Coord::new(48 + 16, 16 + yoffset), 1u8.into()).into_iter());
 
-    disp.draw(Circle::new((96, yoffset + 8), 8, 1u8).into_iter());
+    disp.draw(Circle::new(Coord::new(96, yoffset + 8), 8, 1u8.into()).into_iter());
 
     disp.flush().unwrap();
 }

--- a/examples/image_i2c.rs
+++ b/examples/image_i2c.rs
@@ -68,7 +68,7 @@ fn main() {
     disp.init().unwrap();
     disp.flush().unwrap();
 
-    let im = Image1BPP::new(include_bytes!("./rust.raw"), 64, 64).translate((32, 0));
+    let im = Image1BPP::new(include_bytes!("./rust.raw"), 64, 64).translate(Coord::new(32, 0));
 
     disp.draw(im.into_iter());
 

--- a/examples/rotation_i2c.rs
+++ b/examples/rotation_i2c.rs
@@ -78,7 +78,7 @@ fn main() {
     let (w, h) = disp.get_dimensions();
 
     let im = Image1BPP::new(include_bytes!("./rust.raw"), 64, 64)
-        .translate((w as u32 / 2 - 64 / 2, h as u32 / 2 - 64 / 2));
+        .translate(Coord::new(w as i32 / 2 - 64 / 2, h as i32 / 2 - 64 / 2));
 
     disp.draw(im.into_iter());
 

--- a/examples/text_i2c.rs
+++ b/examples/text_i2c.rs
@@ -63,10 +63,10 @@ fn main() {
     disp.init().unwrap();
     disp.flush().unwrap();
 
-    disp.draw(Font6x8::render_str("Hello world!").into_iter());
+    disp.draw(Font6x8::render_str("Hello world!", 1u8.into()).into_iter());
     disp.draw(
-        Font6x8::render_str("Hello Rust!")
-            .translate((0, 16))
+        Font6x8::render_str("Hello Rust!", 1u8.into())
+            .translate(Coord::new(0, 16))
             .into_iter(),
     );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,10 +143,10 @@
 //!
 //!     disp.init().unwrap();
 //!     disp.flush().unwrap();
-//!     disp.draw(Font6x8::render_str("Hello world!").into_iter());
+//!     disp.draw(Font6x8::render_str("Hello world!", 1u8.into()).into_iter());
 //!     disp.draw(
 //!         Font6x8::render_str("Hello Rust!")
-//!             .translate((0, 16))
+//!             .translate(Coord::new(0, 16))
 //!             .into_iter(),
 //!     );
 //!     disp.flush().unwrap();

--- a/src/mode/graphics.rs
+++ b/src/mode/graphics.rs
@@ -7,11 +7,11 @@
 //!
 //! display.init().unwrap();
 //! display.flush().unwrap();
-//! display.draw(Line::new((0, 0), (16, 16), 1).into_iter());
-//! display.draw(Rect::new((24, 0), (40, 16), 1u8).into_iter());
-//! display.draw(Circle::new((64, 8), 8, 1u8).into_iter());
+//! display.draw(Line::new(Coord::new(0, 0), (16, 16), 1.into()).into_iter());
+//! display.draw(Rect::new(Coord::new(24, 0), (40, 16), 1u8.into()).into_iter());
+//! display.draw(Circle::new(Coord::new(64, 8), 8, 1u8.into()).into_iter());
 //! display.draw(Image1BPP::new(image, 0, 24));
-//! display.draw(Font6x8::render_str("Hello Rust!").translate((24, 24)).into_iter());
+//! display.draw(Font6x8::render_str("Hello Rust!", 1u8.into()).translate(Coord::new(24, 24)).into_iter());
 //! display.flush().unwrap();
 //! ```
 
@@ -158,21 +158,19 @@ where
 #[cfg(feature = "graphics")]
 extern crate embedded_graphics;
 #[cfg(feature = "graphics")]
-use self::embedded_graphics::drawable;
-#[cfg(feature = "graphics")]
-use self::embedded_graphics::Drawing;
+use self::embedded_graphics::{drawable, Drawing, pixelcolor::PixelColorU8};
 
 #[cfg(feature = "graphics")]
-impl<DI> Drawing for GraphicsMode<DI>
+impl<DI> Drawing<PixelColorU8> for GraphicsMode<DI>
 where
     DI: DisplayInterface,
 {
     fn draw<T>(&mut self, item_pixels: T)
     where
-        T: Iterator<Item = drawable::Pixel>,
+        T: Iterator<Item = drawable::Pixel<PixelColorU8>>,
     {
-        for (pos, color) in item_pixels {
-            self.set_pixel(pos.0, pos.1, color);
+        for pixel in item_pixels {
+            self.set_pixel((pixel.0).0, (pixel.0).1, pixel.1.into_inner());
         }
     }
 }


### PR DESCRIPTION
The API for handling Pixels changed, so this change is mostly about updating that. Note that I don't have the hardware to test the examples, so I mostly just checked as far as I could with 'cargo check'. I was able to test the library itself on a Raspberry Pi though.

I'm also not sure how Rust libraries handle changing the major version of libraries they depend on. I guess this would be considered a breaking change?
