### PR TITLE
Don't wrap around when x >= width

### DIFF
--- a/src/mode/graphics.rs
+++ b/src/mode/graphics.rs
@@ -100,10 +100,16 @@ where
 
         let idx = match display_rotation {
             DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => {
+                if x >= display_width as u32 {
+                    return;
+                }
                 ((y as usize) / 8 * display_width as usize) + (x as usize)
             }
 
             DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => {
+                if y >= display_width as u32 {
+                    return;
+                }
                 ((x as usize) / 8 * display_width as usize) + (y as usize)
             }
         };


### PR DESCRIPTION
`set_pixel` already does nothing if pixel memory index is larger than buffer size.

However, when pixel overflows by x, it simply overflows into the next row (y coordinate) instead of being ignored.

This commit fixes it, and causes it to be ignored.