### PR TITLE
Terminal mode cursor

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -42,6 +42,10 @@ pub enum Command {
     /// 4 bits given.
     /// This is only for page addressing mode
     UpperColStart(u8),
+    /// Set the column start address register for Page addressing mode.
+    /// Combines LowerColStart and UpperColStart
+    /// This is only for page addressing mode
+    ColStart(u8),
     /// Set addressing mode
     AddressMode(AddrMode),
     /// Setup column start and end address
@@ -121,7 +125,8 @@ impl Command {
             Command::EnableScroll(en) => ([0x2E | (en as u8), 0, 0, 0, 0, 0, 0], 1),
             Command::VScrollArea(above, lines) => ([0xA3, above, lines, 0, 0, 0, 0], 3),
             Command::LowerColStart(addr) => ([0xF & addr, 0, 0, 0, 0, 0, 0], 1),
-            Command::UpperColStart(addr) => ([0x1F & addr, 0, 0, 0, 0, 0, 0], 1),
+            Command::UpperColStart(addr) => ([0x10 | (0xF & addr), 0, 0, 0, 0, 0, 0], 1),
+            Command::ColStart(addr) => ([0xF & addr, 0x10 | (0xF & (addr >> 4)), 0, 0, 0, 0, 0], 2),
             Command::AddressMode(mode) => ([0x20, mode as u8, 0, 0, 0, 0, 0], 2),
             Command::ColumnAddress(start, end) => ([0x21, start, end, 0, 0, 0, 0], 3),
             Command::PageAddress(start, end) => ([0x22, start as u8, end as u8, 0, 0, 0, 0], 3),

--- a/src/mode/terminal.rs
+++ b/src/mode/terminal.rs
@@ -96,6 +96,7 @@ impl Cursor {
 }
 
 /// Errors which can occur when interacting with the terminal mode
+#[derive(Clone)]
 pub enum TerminalModeError<DI>
 where
     DI: DisplayInterface,
@@ -106,6 +107,19 @@ where
     Uninitialized,
     /// A location was specified outside the bounds of the screen
     OutOfBounds,
+}
+
+impl<DI> core::fmt::Debug for TerminalModeError<DI>
+where
+    DI: DisplayInterface,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
+        match self {
+            InterfaceError(_) => "InterfaceError".fmt(f),
+            Uninitialized => "Uninitialized".fmt(f),
+            OutOfBounds => "OutOfBound".fmt(f),
+        }
+    }
 }
 
 // Cannot use From<_> due to coherence

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -99,10 +99,10 @@ where
     /// Set the column address in the framebuffer of the display where any sent data should be
     /// drawn.
     /// Only works in Page addressing mode.
-    pub fn set_column(&mut self, column: u8) -> Result<(), DI::Error> {
+    pub fn set_column(&mut self, column: u8) -> Result<(), ()> {
         match self.addr_mode {
             AddrMode::Page => Command::ColStart(column).send(&mut self.iface),
-            _ => Err(()), // TODO
+            _ => Err(()),
         }
     }
 
@@ -111,10 +111,10 @@ where
     /// Note that the parameter is in pixels, but the page will be set to the start of the 8px
     /// row which contains the passed-in row.
     /// Only works in Page addressing mode.
-    pub fn set_row(&mut self, row: u8) -> Result<(), DI::Error> {
+    pub fn set_row(&mut self, row: u8) -> Result<(), ()> {
         match self.addr_mode {
             AddrMode::Page => Command::PageStart(row.into()).send(&mut self.iface),
-            _ => Err(()), // TODO
+            _ => Err(()),
         }
     }
 
@@ -189,11 +189,12 @@ where
             }
         };
 
-    Ok(())
+        Ok(())
     }
 
     /// Turn the display on or off. The display can be drawn to and retains all
     /// of its memory even while off.
     pub fn display_on(&mut self, on: bool) -> Result<(), DI::Error> {
         Command::DisplayOn(on).send(&mut self.iface)
+    }
 }

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -87,7 +87,7 @@ where
     /// Only works in Horizontal or Vertical addressing mode
     pub fn set_draw_area(&mut self, start: (u8, u8), end: (u8, u8)) -> Result<(), DI::Error> {
         match self.addr_mode {
-            AddrMode::Page => Err(()),
+            AddrMode::Page => panic!("Device cannot be in Page mode to set draw area"),
             _ => {
                 Command::ColumnAddress(start.0, end.0 - 1).send(&mut self.iface)?;
                 Command::PageAddress(start.1.into(), (end.1 - 1).into()).send(&mut self.iface)?;
@@ -99,10 +99,10 @@ where
     /// Set the column address in the framebuffer of the display where any sent data should be
     /// drawn.
     /// Only works in Page addressing mode.
-    pub fn set_column(&mut self, column: u8) -> Result<(), ()> {
+    pub fn set_column(&mut self, column: u8) -> Result<(), DI::Error> {
         match self.addr_mode {
             AddrMode::Page => Command::ColStart(column).send(&mut self.iface),
-            _ => Err(()),
+            _ => panic!("Device must be in Page mode to set column"),
         }
     }
 
@@ -111,10 +111,10 @@ where
     /// Note that the parameter is in pixels, but the page will be set to the start of the 8px
     /// row which contains the passed-in row.
     /// Only works in Page addressing mode.
-    pub fn set_row(&mut self, row: u8) -> Result<(), ()> {
+    pub fn set_row(&mut self, row: u8) -> Result<(), DI::Error> {
         match self.addr_mode {
             AddrMode::Page => Command::PageStart(row.into()).send(&mut self.iface),
-            _ => Err(()),
+            _ => panic!("Device must be in Page mode to set row"),
         }
     }
 


### PR DESCRIPTION
This supersedes #79 by tracking the full vertical and horizontal position ourselves within `TerminalMode`, and implementing line-wrapping manually. This means we can use the `Page` addressing mode, so we can write characters to arbitrary points on the screen, while still remaining bufferless. As a bonus, we can handle `\r` properly.

There may be places that this could be cleaned up—I especially don't like the potential confusion between "pages" and "rows" and the magic `* 8` which needs to be in place (it probably needs a few wrapper types). It does work though—tested manually over I2C on a cheap AliExpress SSD1306 board.

Closes #78 