### PR TITLE
Implement switching display power

### DIFF
--- a/src/mode/graphics.rs
+++ b/src/mode/graphics.rs
@@ -162,6 +162,11 @@ where
     pub fn set_rotation(&mut self, rot: DisplayRotation) -> Result<(), DI::Error> {
         self.properties.set_rotation(rot)
     }
+
+    /// Turn the display on or off
+    pub fn set_power(&mut self, turn_on: bool) -> Result<(), DI::Error> {
+        self.properties.set_power(turn_on)
+    }
 }
 
 #[cfg(feature = "graphics")]

--- a/src/mode/graphics.rs
+++ b/src/mode/graphics.rs
@@ -163,9 +163,10 @@ where
         self.properties.set_rotation(rot)
     }
 
-    /// Turn the display on or off
-    pub fn set_power(&mut self, turn_on: bool) -> Result<(), DI::Error> {
-        self.properties.set_power(turn_on)
+    /// Turn the display on or off. The display can be drawn to and retains all
+    /// of its memory even while off.
+    pub fn display_on(&mut self, on: bool) -> Result<(), DI::Error> {
+        self.properties.display_on(on)
     }
 }
 

--- a/src/mode/terminal.rs
+++ b/src/mode/terminal.rs
@@ -228,6 +228,11 @@ where
     pub fn set_rotation(&mut self, rot: DisplayRotation) -> Result<(), DI::Error> {
         self.properties.set_rotation(rot)
     }
+
+    /// Turn the display on or off
+    pub fn set_power(&mut self, turn_on: bool) -> Result<(), DI::Error> {
+        self.properties.set_power(turn_on)
+    }
 }
 
 impl<DI> fmt::Write for TerminalMode<DI>

--- a/src/mode/terminal.rs
+++ b/src/mode/terminal.rs
@@ -229,9 +229,10 @@ where
         self.properties.set_rotation(rot)
     }
 
-    /// Turn the display on or off
-    pub fn set_power(&mut self, turn_on: bool) -> Result<(), DI::Error> {
-        self.properties.set_power(turn_on)
+    /// Turn the display on or off. The display can be drawn to and retains all
+    /// of its memory even while off.
+    pub fn display_on(&mut self, on: bool) -> Result<(), DI::Error> {
+        self.properties.display_on(on)
     }
 }
 

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -149,4 +149,9 @@ where
             }
         }
     }
+
+    /// Turn the display on or off
+    pub fn set_power(&mut self, turn_on: bool) -> Result<(), DI::Error> {
+        Command::DisplayOn(turn_on).send(&mut self.iface)
+    }
 }

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -150,8 +150,9 @@ where
         }
     }
 
-    /// Turn the display on or off
-    pub fn set_power(&mut self, turn_on: bool) -> Result<(), DI::Error> {
-        Command::DisplayOn(turn_on).send(&mut self.iface)
+    /// Turn the display on or off. The display can be drawn to and retains all
+    /// of its memory even while off.
+    pub fn display_on(&mut self, on: bool) -> Result<(), DI::Error> {
+        Command::DisplayOn(on).send(&mut self.iface)
     }
 }


### PR DESCRIPTION
Implements #84 . Tested using [Adafruit OLED Featherwing](https://www.adafruit.com/product/2900). Display has no issues accepting commands while switched off so I don't believe there is a need to implement any interlocks or new state.

Closes #84 