### PR TITLE
Clarify builder docs, test doc examples in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,9 @@ matrix:
     - rust: beta
     - rust: nightly
 
+before_install:
+  - pip install linkchecker --user
+
 install:
   - rustup component add rust-src
   - |
@@ -51,6 +54,8 @@ install:
 
 script:
   - ./build.sh
+  - cargo doc --all-features --target $TARGET
+  - linkchecker target/$TARGET/doc/ssd1306/index.html
 
 cache: cargo
 before_cache:

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,9 @@ set -e
 
 cargo build --target $TARGET --all-features --release
 
+cargo test --lib --target x86_64-unknown-linux-gnu
+cargo test --doc --target x86_64-unknown-linux-gnu
+
 if [ -z $DISABLE_EXAMPLES ]; then
 	cargo build --target $TARGET --all-features --examples
 fi

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -12,17 +12,21 @@
 //!
 //! Connect over SPI with default rotation (0 deg) and size (128x64):
 //!
-//! ```rust,ignore
-//! let spi = /* SPI interface from your HAL of choice */;
-//! let dc = /* GPIO data/command select pin */;
+//! ```rust
+//! # use ssd1306::test_helpers::{PinStub, SpiStub};
+//! # let spi = SpiStub;
+//! # let dc = PinStub;
+//! use ssd1306::Builder;
 //!
 //! Builder::new().connect_spi(spi, dc);
 //! ```
 //!
 //! Connect over I2C, changing lots of options
 //!
-//! ```rust,ignore
-//! let i2c = /* I2C interface from your HAL of choice */;
+//! ```rust
+//! # use ssd1306::test_helpers::{PinStub, I2cStub};
+//! # let i2c = I2cStub;
+//! use ssd1306::{prelude::*, Builder};
 //!
 //! Builder::new()
 //!     .with_rotation(DisplayRotation::Rotate180)
@@ -35,9 +39,11 @@
 //! by default. You need to coerce them into a mode by specifying a type on assignment. For
 //! example, to use [`TerminalMode` mode](../mode/terminal/struct.TerminalMode.html):
 //!
-//! ```rust,ignore
-//! let spi = /* SPI interface from your HAL of choice */;
-//! let dc = /* GPIO data/command select pin */;
+//! ```rust
+//! # use ssd1306::test_helpers::{PinStub, SpiStub};
+//! # let spi = SpiStub;
+//! # let dc = PinStub;
+//! use ssd1306::{prelude::*, Builder};
 //!
 //! let display: TerminalMode<_> = Builder::new().connect_spi(spi, dc).into();
 //! ```

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -96,6 +96,8 @@ impl Builder {
     }
 
     /// Finish the builder and use I2C to communicate with the display
+    ///
+    /// This method consumes the builder and must come last in the method call chain
     pub fn connect_i2c<I2C, CommE>(&self, i2c: I2C) -> DisplayMode<RawMode<I2cInterface<I2C>>>
     where
         I2C: hal::blocking::i2c::Write<Error = CommE>,
@@ -109,6 +111,8 @@ impl Builder {
     }
 
     /// Finish the builder and use SPI to communicate with the display
+    ///
+    /// This method consumes the builder and must come last in the method call chain
     pub fn connect_spi<SPI, DC, CommE, PinE>(
         &self,
         spi: SPI,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,9 +1,11 @@
 //! Interface factory
 //!
-//! This is the easiest way to create a driver instance. You can set various parameters of the
-//! driver and give it an interface to use. The builder will return a
-//! [`mode::RawMode`](../mode/raw/struct.RawMode.html) object which you should coerce to a richer
-//! display mode, like [mode::Graphics](../mode/graphics/struct.GraphicsMode.html) for drawing
+//! This is the easiest way to create a driver instance, with the ability to set various parameters of the driver.
+//!
+//! To finish the builder and produce a connected display interface, call `.connect_i2c(i2c)` or
+//! `.connect_spi(spi, dc)`. The builder will be consumed into a
+//! [`mode::RawMode`](../mode/raw/struct.RawMode.html) object which can be coerced into a richer
+//! display mode like [mode::Graphics](../mode/graphics/struct.GraphicsMode.html) for drawing
 //! primitives and text.
 //!
 //! # Examples

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -9,14 +9,12 @@
 //! a type alias. Here's an example for the I2C1 on an STM32F103xx:
 //!
 //! ```rust
-//! # extern crate ssd1306;
-//! # extern crate stm32f103xx_hal as hal;
-//! # use hal::gpio::gpiob::{PB8, PB9};
-//! # use hal::gpio::{Alternate, OpenDrain};
-//! # use hal::i2c::I2c;
-//! # use hal::prelude::*;
-//! # use hal::stm32f103xx::I2C1;
-//! # use ssd1306::interface::I2cInterface;
+//! # use stm32f1xx_hal::gpio::gpiob::{PB8, PB9};
+//! # use stm32f1xx_hal::gpio::{Alternate, OpenDrain};
+//! # use stm32f1xx_hal::i2c::I2c;
+//! # use stm32f1xx_hal::pac::I2C1;
+//! # use stm32f1xx_hal::prelude::*;
+//! use ssd1306::{interface::I2cInterface, prelude::*};
 //! type OledDisplay =
 //!   GraphicsMode<I2cInterface<I2c<I2C1, (PB8<Alternate<OpenDrain>>, PB9<Alternate<OpenDrain>>)>>>;
 //! ```
@@ -26,14 +24,13 @@
 //! Here's one for SPI1 on an STM32F103xx:
 //!
 //! ```rust
-//! # extern crate ssd1306;
-//! # extern crate stm32f103xx_hal as hal;
-//! # use hal::gpio::gpioa::{PA5, PA6, PA7};
-//! # use hal::gpio::gpiob::PB1;
-//! # use hal::gpio::{Alternate, Floating, Input, Output, PushPull};
-//! # use hal::spi::Spi;
-//! # use hal::stm32f103xx::SPI1;
-//! # use ssd1306::interface::SpiInterface;
+//! # use stm32f1xx_hal::gpio::gpioa::{PA5, PA6, PA7};
+//! # use stm32f1xx_hal::gpio::gpiob::PB1;
+//! # use stm32f1xx_hal::gpio::{Alternate, Floating, Input, Output, PushPull};
+//! # use stm32f1xx_hal::pac::SPI1;
+//! # use stm32f1xx_hal::prelude::*;
+//! # use stm32f1xx_hal::spi::Spi;
+//! use ssd1306::{interface::SpiInterface, prelude::*};
 //! pub type OledDisplay = GraphicsMode<
 //!     SpiInterface<
 //!         Spi<

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! The driver must be initialised by passing an I2C or SPI interface peripheral to the [`Builder`],
 //! which will in turn create a driver instance in a particular mode. By default, the builder
-//! returns a [`mode::RawMode`] instance which isn't very useful by itself. You can coerce the driver
+//! returns a [`RawMode`] instance which isn't very useful by itself. You can coerce the driver
 //! into a more useful mode by calling `into()` and defining the type you want to coerce to. For
 //! example, to initialise the display with an I2C interface and [`GraphicsMode`], you would do
 //! something like this:
@@ -24,7 +24,7 @@
 //! for more usage. The [entire `embedded_graphics` featureset](https://github.com/jamwaffles/embedded-graphics#features)
 //! is supported by this driver.
 //!
-//! There is also [mode::TerminalMode] which allows drawing of characters to the display without
+//! There is also [`TerminalMode`] which allows drawing of characters to the display without
 //! using a display buffer:
 //!
 //! ```rust
@@ -43,7 +43,7 @@
 //! for more usage.
 //!
 //! It's possible to customise the driver to suit your display/application. Take a look at the
-//! [Builder] for available options.
+//! [`Builder`] for available options.
 //!
 //! # Examples
 //!
@@ -52,7 +52,7 @@
 //!
 //! ## Write text to the display without a framebuffer
 //!
-//! Uses [mode::TerminalMode]. [See the complete example
+//! Uses [`TerminalMode`]. [See the complete example
 //! here](https://github.com/jamwaffles/ssd1306/blob/master/examples/terminal_i2c.rs).
 //!
 //! ```rust
@@ -105,7 +105,10 @@
 //! disp.flush().unwrap();
 //! ```
 //!
+//! [`Builder`]: ./builder/struct.Builder.html
 //! [`GraphicsMode`]: ./mode/graphics/struct.GraphicsMode.html
+//! [`TerminalMode`]: ./mode/graphics/struct.TerminalMode.html
+//! [`RawMode`]: ./mode/graphics/struct.RawMode.html
 
 #![no_std]
 // #![deny(missing_debug_implementations)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,8 +107,8 @@
 //!
 //! [`Builder`]: ./builder/struct.Builder.html
 //! [`GraphicsMode`]: ./mode/graphics/struct.GraphicsMode.html
-//! [`TerminalMode`]: ./mode/graphics/struct.TerminalMode.html
-//! [`RawMode`]: ./mode/graphics/struct.RawMode.html
+//! [`TerminalMode`]: ./mode/terminal/struct.TerminalMode.html
+//! [`RawMode`]: ./mode/raw/struct.RawMode.html
 
 #![no_std]
 // #![deny(missing_debug_implementations)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,11 +4,15 @@
 //! which will in turn create a driver instance in a particular mode. By default, the builder
 //! returns a [`mode::RawMode`] instance which isn't very useful by itself. You can coerce the driver
 //! into a more useful mode by calling `into()` and defining the type you want to coerce to. For
-//! example, to initialise the display with an I2C interface and [mode::GraphicsMode], you would do
+//! example, to initialise the display with an I2C interface and [`GraphicsMode`], you would do
 //! something like this:
 //!
-//! ```rust,ignore
-//! let i2c = I2c::i2c1(/* snip */);
+//! ```rust
+//! # use ssd1306::test_helpers::I2cStub as I2cInterface;
+//! use ssd1306::{Builder, mode::GraphicsMode};
+//!
+//! // Configure an I2C interface on the target device; below line shown as example only
+//! let i2c = I2cInterface;
 //!
 //! let mut disp: GraphicsMode<_> = Builder::new().connect_i2c(i2c).into();
 //! disp.init();
@@ -23,8 +27,12 @@
 //! There is also [mode::TerminalMode] which allows drawing of characters to the display without
 //! using a display buffer:
 //!
-//! ```rust,ignore
-//! let i2c = I2c::i2c1(/* snip */);
+//! ```rust
+//! # use ssd1306::test_helpers::I2cStub as I2cInterface;
+//! use ssd1306::{mode::TerminalMode, Builder};
+//!
+//! // Configure an I2C interface on the target device; below line shown as example only
+//! let i2c = I2cInterface;
 //!
 //! let mut disp: TerminalMode<_> = Builder::new().connect_i2c(i2c).into();
 //!
@@ -44,117 +52,62 @@
 //!
 //! ## Write text to the display without a framebuffer
 //!
-//! Uses [mode::TerminalMode].
+//! Uses [mode::TerminalMode]. [See the complete example
+//! here](https://github.com/jamwaffles/ssd1306/blob/master/examples/terminal_i2c.rs).
 //!
-//! ```rust,no-run
-//! #![no_std]
-//!
-//! extern crate cortex_m;
-//! extern crate embedded_hal as hal;
-//! extern crate panic_abort;
-//! extern crate ssd1306;
-//! extern crate stm32f103xx_hal as blue_pill;
-//!
-//! use blue_pill::i2c::{DutyCycle, I2c, Mode};
-//! use blue_pill::prelude::*;
+//! ```rust
+//!	# use ssd1306::test_helpers::I2cStub;
+//!	# let i2c = I2cStub;
 //! use core::fmt::Write;
-//! use ssd1306::{mode::TerminalMode, Builder};
+//! use ssd1306::{prelude::*, mode::TerminalMode, Builder};
 //!
-//! fn main() {
-//!     let dp = blue_pill::stm32f103xx::Peripherals::take().unwrap();
-//!     let mut flash = dp.FLASH.constrain();
-//!     let mut rcc = dp.RCC.constrain();
-//!     let clocks = rcc.cfgr.freeze(&mut flash.acr);
-//!     let mut afio = dp.AFIO.constrain(&mut rcc.apb2);
-//!     let mut gpiob = dp.GPIOB.split(&mut rcc.apb2);
-//!     let scl = gpiob.pb8.into_alternate_open_drain(&mut gpiob.crh);
-//!     let sda = gpiob.pb9.into_alternate_open_drain(&mut gpiob.crh);
-//!     let i2c = I2c::i2c1(
-//!         dp.I2C1,
-//!         (scl, sda),
-//!         &mut afio.mapr,
-//!         Mode::Fast {
-//!             frequency: 400_000,
-//!             duty_cycle: DutyCycle::Ratio1to1,
-//!         },
-//!         clocks,
-//!         &mut rcc.apb1,
-//!     );
+//! let mut disp: TerminalMode<_> = Builder::new().connect_i2c(i2c).into();
+//! disp.init().unwrap();
+//! let _ = disp.clear();
 //!
-//!     let mut disp: TerminalMode<_> = Builder::new().connect_i2c(i2c).into();
-//!     disp.init().unwrap();
-//!     disp.clear().unwrap();
-//!
-//!     // Endless loop
-//!     loop {
-//!         for c in 97..123 {
-//!             let _ = disp.write_str(unsafe { core::str::from_utf8_unchecked(&[c]) });
-//!         }
-//!         for c in 65..91 {
-//!             let _ = disp.write_str(unsafe { core::str::from_utf8_unchecked(&[c]) });
-//!         }
-//!     }
+//! // Spam some characters to the display
+//! for c in 97..123 {
+//!     let _ = disp.write_str(unsafe { core::str::from_utf8_unchecked(&[c]) });
+//! }
+//! for c in 65..91 {
+//!     let _ = disp.write_str(unsafe { core::str::from_utf8_unchecked(&[c]) });
 //! }
 //! ```
 //!
 //! ## Draw some text to the display
 //!
-//! Uses [mode::GraphicsMode] and [embedded_graphics](../embedded_graphics/index.html).
+//! Uses [`GraphicsMode`] and [embedded_graphics](../embedded_graphics/index.html). [See the
+//! complete example here](https://github.com/jamwaffles/ssd1306/blob/master/examples/text_i2c.rs).
 //!
-//! ```rust,no-run
-//! #![no_std]
+//! ```rust
+//!	# use ssd1306::test_helpers::I2cStub;
+//!	# let i2c = I2cStub;
+//! use ssd1306::{prelude::*, mode::GraphicsMode, Builder};
+//! use embedded_graphics::{prelude::*, fonts::Font6x8};
 //!
-//! extern crate cortex_m;
-//! extern crate embedded_graphics;
-//! extern crate embedded_hal as hal;
-//! extern crate panic_abort;
-//! extern crate ssd1306;
-//! extern crate stm32f103xx_hal as blue_pill;
+//! let mut disp: GraphicsMode<_> = Builder::new().connect_i2c(i2c).into();
 //!
-//! use blue_pill::i2c::{DutyCycle, I2c, Mode};
-//! use blue_pill::prelude::*;
-//! use embedded_graphics::fonts::Font6x8;
-//! use embedded_graphics::prelude::*;
-//! use ssd1306::{mode::GraphicsMode, Builder};
+//! disp.init().unwrap();
+//! disp.flush().unwrap();
 //!
-//! fn main() {
-//!     let dp = blue_pill::stm32f103xx::Peripherals::take().unwrap();
-//!     let mut flash = dp.FLASH.constrain();
-//!     let mut rcc = dp.RCC.constrain();
-//!     let clocks = rcc.cfgr.freeze(&mut flash.acr);
-//!     let mut afio = dp.AFIO.constrain(&mut rcc.apb2);
-//!     let mut gpiob = dp.GPIOB.split(&mut rcc.apb2);
-//!     let scl = gpiob.pb8.into_alternate_open_drain(&mut gpiob.crh);
-//!     let sda = gpiob.pb9.into_alternate_open_drain(&mut gpiob.crh);
+//! disp.draw(
+//!     Font6x8::render_str("Hello world!")
+//!         .with_stroke(Some(1u8.into()))
+//!         .into_iter(),
+//! );
+//! disp.draw(
+//!     Font6x8::render_str("Hello Rust!")
+//!         .with_stroke(Some(1u8.into()))
+//!         .translate(Coord::new(0, 16))
+//!         .into_iter(),
+//! );
 //!
-//!     let i2c = I2c::i2c1(
-//!         dp.I2C1,
-//!         (scl, sda),
-//!         &mut afio.mapr,
-//!         Mode::Fast {
-//!             frequency: 400_000,
-//!             duty_cycle: DutyCycle::Ratio1to1,
-//!         },
-//!         clocks,
-//!         &mut rcc.apb1,
-//!     );
-//!
-//!     let mut disp: GraphicsMode<_> = Builder::new().connect_i2c(i2c).into();
-//!
-//!     disp.init().unwrap();
-//!     disp.flush().unwrap();
-//!     disp.draw(Font6x8::render_str("Hello world!", 1u8.into()).into_iter());
-//!     disp.draw(
-//!         Font6x8::render_str("Hello Rust!")
-//!             .translate(Coord::new(0, 16))
-//!             .into_iter(),
-//!     );
-//!     disp.flush().unwrap();
-//! }
+//! disp.flush().unwrap();
 //! ```
+//!
+//! [`GraphicsMode`]: ./mode/graphics/struct.GraphicsMode.html
 
 #![no_std]
-// TODO: Docs
 // #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 #![deny(warnings)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,5 +185,7 @@ pub mod interface;
 pub mod mode;
 pub mod prelude;
 pub mod properties;
+#[doc(hidden)]
+pub mod test_helpers;
 
 pub use crate::builder::Builder;

--- a/src/mode/graphics.rs
+++ b/src/mode/graphics.rs
@@ -1,19 +1,40 @@
 //! Buffered display module for use with the [embedded_graphics] crate
 //!
-//! ```rust,ignore
-//! let i2c = /* I2C interface from your HAL of choice */;
-//! let display: GraphicsMode<_> = Builder::new().connect_i2c(i2c).into();
-//! let image = include_bytes!("image_16x16.raw");
+//! ```rust
+//! # use ssd1306::test_helpers::I2cStub;
+//! # let i2c = I2cStub;
+//! use ssd1306::{prelude::*, mode::GraphicsMode, Builder};
+//! use embedded_graphics::{prelude::*, primitives::{Line, Rect, Circle}, fonts::Font6x8};
+//!
+//! let mut display: GraphicsMode<_> = Builder::new().connect_i2c(i2c).into();
 //!
 //! display.init().unwrap();
 //! display.flush().unwrap();
-//! display.draw(Line::new(Coord::new(0, 0), (16, 16), 1.into()).into_iter());
-//! display.draw(Rect::new(Coord::new(24, 0), (40, 16), 1u8.into()).into_iter());
-//! display.draw(Circle::new(Coord::new(64, 8), 8, 1u8.into()).into_iter());
-//! display.draw(Image1BPP::new(image, 0, 24));
-//! display.draw(Font6x8::render_str("Hello Rust!", 1u8.into()).translate(Coord::new(24, 24)).into_iter());
+//! display.draw(
+//!     Line::new(Coord::new(0, 0), Coord::new(16, 16))
+//!         .with_stroke(Some(1u8.into()))
+//!         .into_iter(),
+//! );
+//! display.draw(
+//!     Rect::new(Coord::new(24, 0), Coord::new(40, 16))
+//!         .with_stroke(Some(1u8.into()))
+//!         .into_iter(),
+//! );
+//! display.draw(
+//!     Circle::new(Coord::new(64, 8), 8)
+//!         .with_stroke(Some(1u8.into()))
+//!         .into_iter(),
+//! );
+//! display.draw(
+//!     Font6x8::render_str("Hello Rust!")
+//!         .with_stroke(Some(1u8.into()))
+//!         .translate(Coord::new(24, 24))
+//!         .into_iter(),
+//! );
 //! display.flush().unwrap();
 //! ```
+//!
+//! [embedded_graphics]: https://crates.io/crates/embedded_graphics
 
 use hal::blocking::delay::DelayMs;
 use hal::digital::v2::OutputPin;

--- a/src/mode/terminal.rs
+++ b/src/mode/terminal.rs
@@ -5,9 +5,13 @@
 //! left to bottom right in an 8x8 pixel grid, restarting at the top left of the display once full.
 //! The display itself takes care of wrapping lines.
 //!
-//! ```rust,ignore
-//! let i2c = /* I2C interface from your HAL of choice */;
-//! let display: TerminalMode<_> = Builder::new().connect_i2c(i2c).into();
+//! ```rust
+//! # use ssd1306::test_helpers::I2cStub;
+//! # let i2c = I2cStub;
+//! use core::fmt::Write;
+//! use ssd1306::{mode::TerminalMode, Builder};
+//!
+//! let mut display: TerminalMode<_> = Builder::new().connect_i2c(i2c).into();
 //!
 //! display.init().unwrap();
 //! display.clear().unwrap();

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -83,19 +83,12 @@ where
         self.display_size
     }
 
-    // TODO: Replace (u8, u8) with a dimensioney type for consistency
-    // TOOD: Make doc tests work
     /// Get display dimensions, taking into account the current rotation of the display
     ///
     /// ```rust
-    /// # struct FakeInterface;
-    /// #
-    /// # impl DisplayInterface for FakeInterface {
-    /// #     fn send_command(&mut self, cmd: u8) -> Result<(), ()> { Ok(()) }
-    /// #     fn send_data(&mut self, buf: &[u8]) -> Result<(), ()> { Ok(()) }
-    /// # }
-    /// #
-    /// # let interface = FakeInterface {};
+    /// # use ssd1306::{properties::DisplayProperties, test_helpers::StubInterface};
+    /// # let interface = StubInterface;
+    /// use ssd1306::prelude::*;
     /// #
     /// let disp = DisplayProperties::new(
     ///     interface,
@@ -104,7 +97,7 @@ where
     /// );
     /// assert_eq!(disp.get_dimensions(), (128, 64));
     ///
-    /// # let interface = FakeInterface {};
+    /// # let interface = StubInterface;
     /// let rotated_disp = DisplayProperties::new(
     ///     interface,
     ///     DisplaySize::Display128x64,

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1,0 +1,71 @@
+//! Helpers for use in examples and tests
+
+use crate::interface::DisplayInterface;
+use embedded_hal::{
+    blocking::i2c,
+    blocking::spi::{self, Transfer},
+    digital::v2::OutputPin,
+};
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy)]
+pub struct SpiStub;
+
+impl spi::Write<u8> for SpiStub {
+    type Error = ();
+
+    fn write(&mut self, _buf: &[u8]) -> Result<(), ()> {
+        Ok(())
+    }
+}
+
+impl Transfer<u8> for SpiStub {
+    type Error = ();
+
+    fn transfer<'a>(&mut self, buf: &'a mut [u8]) -> Result<&'a [u8], ()> {
+        Ok(buf)
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy)]
+pub struct I2cStub;
+
+impl i2c::Write for I2cStub {
+    type Error = ();
+
+    fn write(&mut self, _addr: u8, _buf: &[u8]) -> Result<(), ()> {
+        Ok(())
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy)]
+pub struct PinStub;
+
+impl OutputPin for PinStub {
+    type Error = ();
+
+    fn set_high(&mut self) -> Result<(), ()> {
+        Ok(())
+    }
+
+    fn set_low(&mut self) -> Result<(), ()> {
+        Ok(())
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy)]
+pub struct StubInterface;
+
+impl DisplayInterface for StubInterface {
+    type Error = ();
+
+    fn send_commands(&mut self, _cmd: &[u8]) -> Result<(), ()> {
+        Ok(())
+    }
+    fn send_data(&mut self, _buf: &[u8]) -> Result<(), ()> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
* Clarify builder docs as per #87 
* Test code examples in CI (also #87)
* Check doc links using `linkchecker` in CI

Closes #87 