### PR TITLE
Improve I2C Flush (Update) Speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ fn main() -> ! {
     let mut disp: GraphicsMode<_> = Builder::new().connect_i2c(i2c).into();
 
     disp.init().unwrap();
-    disp.flush().unwrap();
 
     let im = Image1BPP::new(include_bytes!("./rust.raw"), 64, 64).translate(Coord::new(32, 0));
 

--- a/examples/bmp_i2c.rs
+++ b/examples/bmp_i2c.rs
@@ -72,7 +72,6 @@ fn main() -> ! {
     let mut disp: GraphicsMode<_> = Builder::new().connect_i2c(i2c).into();
 
     disp.init().unwrap();
-    disp.flush().unwrap();
 
     // The image is an RGB565 encoded BMP, so specifying the type as `ImageBmp<Rgb565>` will read
     // the pixels correctly

--- a/examples/graphics.rs
+++ b/examples/graphics.rs
@@ -79,7 +79,6 @@ fn main() -> ! {
 
     disp.reset(&mut rst, &mut delay).unwrap();
     disp.init().unwrap();
-    disp.flush().unwrap();
 
     disp.draw(
         Line::new(Point::new(8, 16 + 16), Point::new(8 + 16, 16 + 16))

--- a/examples/graphics_i2c.rs
+++ b/examples/graphics_i2c.rs
@@ -68,7 +68,6 @@ fn main() -> ! {
     let mut disp: GraphicsMode<_> = Builder::new().connect_i2c(i2c).into();
 
     disp.init().unwrap();
-    disp.flush().unwrap();
 
     disp.draw(
         Line::new(Point::new(8, 16 + 16), Point::new(8 + 16, 16 + 16))

--- a/examples/graphics_i2c_128x32.rs
+++ b/examples/graphics_i2c_128x32.rs
@@ -60,7 +60,6 @@ fn main() -> ! {
         .connect_i2c(i2c)
         .into();
     disp.init().unwrap();
-    disp.flush().unwrap();
 
     let yoffset = 8;
 

--- a/examples/image_i2c.rs
+++ b/examples/image_i2c.rs
@@ -72,7 +72,6 @@ fn main() -> ! {
     let mut disp: GraphicsMode<_> = Builder::new().connect_i2c(i2c).into();
 
     disp.init().unwrap();
-    disp.flush().unwrap();
 
     let im: Image<BinaryColor> =
         Image::new(include_bytes!("./rust.raw"), 64, 64).translate(Point::new(32, 0));

--- a/examples/pixelsquare.rs
+++ b/examples/pixelsquare.rs
@@ -77,7 +77,6 @@ fn main() -> ! {
 
     disp.reset(&mut rst, &mut delay).unwrap();
     disp.init().unwrap();
-    disp.flush().unwrap();
 
     // Top side
     disp.set_pixel(0, 0, 1);

--- a/examples/rotation_i2c.rs
+++ b/examples/rotation_i2c.rs
@@ -76,7 +76,6 @@ fn main() -> ! {
         .into();
 
     disp.init().unwrap();
-    disp.flush().unwrap();
 
     // Contrived example to test builder and instance methods. Sets rotation to 270 degress
     // or 90 degress counterclockwise

--- a/examples/text_i2c.rs
+++ b/examples/text_i2c.rs
@@ -69,7 +69,6 @@ fn main() -> ! {
     let mut disp: GraphicsMode<_> = Builder::new().connect_i2c(i2c).into();
 
     disp.init().unwrap();
-    disp.flush().unwrap();
 
     disp.draw(
         Font6x8::render_str("Hello world!")

--- a/src/interface/i2c.rs
+++ b/src/interface/i2c.rs
@@ -64,7 +64,13 @@ where
         Ok(())
     }
 
-    fn send_bounded_data(&mut self, buf: &[u8], disp_width: usize, upper_left: (u8, u8), lower_right: (u8, u8)) -> Result<(), Self::Error> {
+    fn send_bounded_data(
+        &mut self,
+        buf: &[u8],
+        disp_width: usize,
+        upper_left: (u8, u8),
+        lower_right: (u8, u8),
+    ) -> Result<(), Self::Error> {
         // Noop if the data buffer is empty
         if buf.is_empty() {
             return Ok(());
@@ -81,7 +87,7 @@ where
         // 8.1.5.2 5) b) in the datasheet
         writebuf[0] = 0x40;
 
-        let mut page_offset = starting_page*disp_width;
+        let mut page_offset = starting_page * disp_width;
 
         for _ in 0..=height {
             let start_index = page_offset + upper_left.0 as usize;
@@ -89,7 +95,7 @@ where
 
             page_offset += disp_width;
 
-            let sub_buf = &buf[start_index .. end_index];
+            let sub_buf = &buf[start_index..end_index];
 
             for chunk in sub_buf.chunks(16) {
                 let chunklen = chunk.len();

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -59,6 +59,11 @@ pub trait DisplayInterface {
     fn send_commands(&mut self, cmd: &[u8]) -> Result<(), Self::Error>;
     /// Send data to display.
     fn send_data(&mut self, buf: &[u8]) -> Result<(), Self::Error>;
+    /// Send data to display, taking advantage of bounded data.
+    /// 
+    /// upper_left and lower_right should contain the x and y coordinates of the
+    /// minimum bounding rectangle of the modified pixels.
+    fn send_bounded_data(&mut self, buf: &[u8], disp_width: usize, upper_left: (u8, u8), lower_right: (u8, u8)) -> Result<(), Self::Error>;
 }
 
 pub use self::i2c::I2cInterface;

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -60,10 +60,16 @@ pub trait DisplayInterface {
     /// Send data to display.
     fn send_data(&mut self, buf: &[u8]) -> Result<(), Self::Error>;
     /// Send data to display, taking advantage of bounded data.
-    /// 
+    ///
     /// upper_left and lower_right should contain the x and y coordinates of the
     /// minimum bounding rectangle of the modified pixels.
-    fn send_bounded_data(&mut self, buf: &[u8], disp_width: usize, upper_left: (u8, u8), lower_right: (u8, u8)) -> Result<(), Self::Error>;
+    fn send_bounded_data(
+        &mut self,
+        buf: &[u8],
+        disp_width: usize,
+        upper_left: (u8, u8),
+        lower_right: (u8, u8),
+    ) -> Result<(), Self::Error>;
 }
 
 pub use self::i2c::I2cInterface;

--- a/src/interface/spi.rs
+++ b/src/interface/spi.rs
@@ -67,7 +67,7 @@ where
         for _ in 0..=height {
             let start_index = page_offset + upper_left.0 as usize;
             let end_index = page_offset + lower_right.0 as usize;
-            let sub_buf = &buf[start_index..=end_index];
+            let sub_buf = &buf[start_index..end_index];
 
             page_offset += disp_width;
 

--- a/src/interface/spi.rs
+++ b/src/interface/spi.rs
@@ -48,7 +48,13 @@ where
         self.spi.write(&buf).map_err(Error::Comm)
     }
 
-    fn send_bounded_data(&mut self, buf: &[u8], disp_width: usize, upper_left: (u8, u8), lower_right: (u8, u8)) -> Result<(), Self::Error> {
+    fn send_bounded_data(
+        &mut self,
+        buf: &[u8],
+        disp_width: usize,
+        upper_left: (u8, u8),
+        lower_right: (u8, u8),
+    ) -> Result<(), Self::Error> {
         self.dc.set_high().map_err(Error::Pin)?;
 
         // Divide by 8 since each row is actually 8 pixels tall
@@ -56,12 +62,12 @@ where
 
         let starting_page = (upper_left.1 / 8) as usize;
 
-        let mut page_offset = starting_page*disp_width;
+        let mut page_offset = starting_page * disp_width;
 
         for _ in 0..=height {
             let start_index = page_offset + upper_left.0 as usize;
             let end_index = page_offset + lower_right.0 as usize;
-            let sub_buf = &buf[start_index ..= end_index];
+            let sub_buf = &buf[start_index..=end_index];
 
             page_offset += disp_width;
 

--- a/src/interface/spi.rs
+++ b/src/interface/spi.rs
@@ -47,4 +47,27 @@ where
 
         self.spi.write(&buf).map_err(Error::Comm)
     }
+
+    fn send_bounded_data(&mut self, buf: &[u8], disp_width: usize, upper_left: (u8, u8), lower_right: (u8, u8)) -> Result<(), Self::Error> {
+        self.dc.set_high().map_err(Error::Pin)?;
+
+        // Divide by 8 since each row is actually 8 pixels tall
+        let height = ((lower_right.1 - upper_left.1) / 8) as usize;
+
+        let starting_page = (upper_left.1 / 8) as usize;
+
+        let mut page_offset = starting_page*disp_width;
+
+        for _ in 0..=height {
+            let start_index = page_offset + upper_left.0 as usize;
+            let end_index = page_offset + lower_right.0 as usize;
+            let sub_buf = &buf[start_index ..= end_index];
+
+            page_offset += disp_width;
+
+            self.spi.write(&sub_buf).map_err(Error::Comm)?;
+        }
+
+        Ok(())
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,6 @@
 //! let mut disp: GraphicsMode<_> = Builder::new().connect_i2c(i2c).into();
 //!
 //! disp.init().unwrap();
-//! disp.flush().unwrap();
 //!
 //! disp.draw(
 //!     Font6x8::render_str("Hello world!")

--- a/src/mode/graphics.rs
+++ b/src/mode/graphics.rs
@@ -262,6 +262,7 @@ where
     /// Display is set up in column mode, i.e. a byte walks down a column of 8 pixels from
     /// column 0 on the left, to column _n_ on the right
     pub fn init(&mut self) -> Result<(), DI::Error> {
+        self.clear();
         self.properties.init_column_mode()
     }
 

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -81,10 +81,17 @@ where
     /// Send the data to the display for drawing at the current position in the framebuffer
     /// and advance the position accordingly. Cf. `set_draw_area` to modify the affected area by
     /// this method.
-    /// 
+    ///
     /// This method takes advantage of a bounding box for faster writes.
-    pub fn bounded_draw(&mut self, buffer: &[u8], disp_width: usize, upper_left: (u8, u8), lower_right: (u8, u8)) -> Result<(), DI::Error> {
-        self.iface.send_bounded_data(&buffer, disp_width, upper_left, lower_right)
+    pub fn bounded_draw(
+        &mut self,
+        buffer: &[u8],
+        disp_width: usize,
+        upper_left: (u8, u8),
+        lower_right: (u8, u8),
+    ) -> Result<(), DI::Error> {
+        self.iface
+            .send_bounded_data(&buffer, disp_width, upper_left, lower_right)
     }
 
     /// Get the configured display size

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -78,6 +78,15 @@ where
         self.iface.send_data(&buffer)
     }
 
+    /// Send the data to the display for drawing at the current position in the framebuffer
+    /// and advance the position accordingly. Cf. `set_draw_area` to modify the affected area by
+    /// this method.
+    /// 
+    /// This method takes advantage of a bounding box for faster writes.
+    pub fn bounded_draw(&mut self, buffer: &[u8], disp_width: usize, upper_left: (u8, u8), lower_right: (u8, u8)) -> Result<(), DI::Error> {
+        self.iface.send_bounded_data(&buffer, disp_width, upper_left, lower_right)
+    }
+
     /// Get the configured display size
     pub fn get_size(&self) -> DisplaySize {
         self.display_size

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -68,4 +68,7 @@ impl DisplayInterface for StubInterface {
     fn send_data(&mut self, _buf: &[u8]) -> Result<(), ()> {
         Ok(())
     }
+    fn send_bounded_data(&mut self, _buf: &[u8], _disp_width: usize, _upper_left: (u8, u8), _lower_right: (u8, u8)) -> Result<(), ()> {
+        Ok(())
+    }
 }

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -68,7 +68,13 @@ impl DisplayInterface for StubInterface {
     fn send_data(&mut self, _buf: &[u8]) -> Result<(), ()> {
         Ok(())
     }
-    fn send_bounded_data(&mut self, _buf: &[u8], _disp_width: usize, _upper_left: (u8, u8), _lower_right: (u8, u8)) -> Result<(), ()> {
+    fn send_bounded_data(
+        &mut self,
+        _buf: &[u8],
+        _disp_width: usize,
+        _upper_left: (u8, u8),
+        _lower_right: (u8, u8),
+    ) -> Result<(), ()> {
         Ok(())
     }
 }


### PR DESCRIPTION
This increases the performance of the I2C interface and possibly the SPI interface as well, but I don't have a SPI-based SSD1306 for verification. The main idea comes from the fact that the SSD1306 has support for writing to a subset of the display memory buffer as if it were contiguous. This means that if you only have a small window within the display to update, you don't have to update the entire display.

This is achieved by keeping track of the locations of the pixels that have changed since the last call to flush or reset. The only values we need to track are the max and min values for the x and y coordinates of each pixel. Once a new call to flush happens (fast_flush in this pull request), the elements of the display buffer on the micro-controller that are within the minimum bounding rectangle of changed pixels are copied to a secondary buffer, the SSD1306 is commanded to work with the window subset of the minimum bounding rectangle, and the secondary buffer is sent to the SSD1306.

I have been developing on the STM32F411-DISCOVERY board since my Blue Pills are still on their way across the ocean so I can't speak to the results with the Blue Pill, but I have seen some truly impressive results with the Discovery board. If you are only updating half of the display size, the fast_flush results in a 28.5% faster update. If you are only updating a quarter of the display, that jumps up to a 61.9% faster update.

The downside of this approach is that the micro-controller does have to do some additional computation while copying the changed pixels into a secondary buffer. This means that as the size of the minimum bounding rectangle approaches the display size, the fast_flush approach actually becomes slower than just updating the entire display. When the update area is greater than 75% of the display area, fast_flush calls flush to do a full display update.

Perhaps the biggest performance jump may come from changing the draw function to take an iterator as a parameter instead of a slice, but I'm not sure how that would work and if that would introduce any breaking changes.

# Improvements

 - Faster screen updates when using an I2C DisplayInterface
   * The smaller the area of the screen you are writing to, the faster the update

# Problems

 - Need to double the buffer size
   * This would only be for 128x68 displays since smaller displays could reuse space in the buffer
   * This may also be negated by using iterators instead of slices
 - Faster screen update times might not be a good thing
   * Since the current flush call updates the entire screen, the function always takes the same amount of time to return
   * Maybe some users are using this consistent return time as a key part of their program?