### PR TITLE
examples/graphics*.rs: use new 'Triangle' primitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 [`ssd1306`](https://crates.io/crates/ssd1306) is a no-std driver written in Rust for the popular SSD1306 monochrome OLED display.
 
+## Unreleased
+
+### Changed
+
+- [#97](https://github.com/jamwaffles/ssd1306/pull/97) Use the new `Triangle` primitive from Embedded Graphics 0.6.0-alpha.2 in the three SSD1306 `graphics*.rs` examples
+
 ## 0.3.0-alpha.2
 
 ### Fixed

--- a/examples/graphics.rs
+++ b/examples/graphics.rs
@@ -96,7 +96,7 @@ fn main() -> ! {
         Triangle::new(
             Point::new(16, 16 + yoffset),
             Point::new(16 + 16, 16 + yoffset),
-            Point::new(16 + 8, yoffset)
+            Point::new(16 + 8, yoffset),
         )
         .stroke(Some(BinaryColor::On))
         .into_iter(),
@@ -104,12 +104,9 @@ fn main() -> ! {
 
     // square
     disp.draw(
-        Rectangle::new(
-            Point::new(52, yoffset),
-            Point::new(52 + 16, 16 + yoffset)
-        )
-        .stroke(Some(BinaryColor::On))
-        .into_iter(),
+        Rectangle::new(Point::new(52, yoffset), Point::new(52 + 16, 16 + yoffset))
+            .stroke(Some(BinaryColor::On))
+            .into_iter(),
     );
 
     // circle

--- a/examples/graphics.rs
+++ b/examples/graphics.rs
@@ -29,7 +29,7 @@ use cortex_m_rt::ExceptionFrame;
 use cortex_m_rt::{entry, exception};
 use embedded_graphics::pixelcolor::BinaryColor;
 use embedded_graphics::prelude::*;
-use embedded_graphics::primitives::{Circle, Line, Rectangle};
+use embedded_graphics::primitives::{Circle, Rectangle, Triangle};
 use hal::delay::Delay;
 use hal::prelude::*;
 use hal::spi::{Mode, Phase, Polarity, Spi};
@@ -80,30 +80,41 @@ fn main() -> ! {
     disp.reset(&mut rst, &mut delay).unwrap();
     disp.init().unwrap();
 
+    let yoffset = 20;
+
+    // screen outline
+    // default display size is 128x64 if you don't pass a _DisplaySize_
+    // enum to the _Builder_ struct
     disp.draw(
-        Line::new(Point::new(8, 16 + 16), Point::new(8 + 16, 16 + 16))
-            .stroke(Some(BinaryColor::On))
-            .into_iter(),
-    );
-    disp.draw(
-        Line::new(Point::new(8, 16 + 16), Point::new(8 + 8, 16))
-            .stroke(Some(BinaryColor::On))
-            .into_iter(),
-    );
-    disp.draw(
-        Line::new(Point::new(8 + 16, 16 + 16), Point::new(8 + 8, 16))
+        Rectangle::new(Point::new(0, 0), Point::new(127, 63))
             .stroke(Some(BinaryColor::On))
             .into_iter(),
     );
 
+    // triangle
     disp.draw(
-        Rectangle::new(Point::new(48, 16), Point::new(48 + 16, 16 + 16))
-            .stroke(Some(BinaryColor::On))
-            .into_iter(),
+        Triangle::new(
+            Point::new(16, 16 + yoffset),
+            Point::new(16 + 16, 16 + yoffset),
+            Point::new(16 + 8, yoffset)
+        )
+        .stroke(Some(BinaryColor::On))
+        .into_iter(),
     );
 
+    // square
     disp.draw(
-        Circle::new(Point::new(96, 16 + 8), 8)
+        Rectangle::new(
+            Point::new(52, yoffset),
+            Point::new(52 + 16, 16 + yoffset)
+        )
+        .stroke(Some(BinaryColor::On))
+        .into_iter(),
+    );
+
+    // circle
+    disp.draw(
+        Circle::new(Point::new(96, yoffset + 8), 8)
             .stroke(Some(BinaryColor::On))
             .into_iter(),
     );

--- a/examples/graphics_i2c.rs
+++ b/examples/graphics_i2c.rs
@@ -26,7 +26,7 @@ use cortex_m_rt::ExceptionFrame;
 use cortex_m_rt::{entry, exception};
 use embedded_graphics::pixelcolor::BinaryColor;
 use embedded_graphics::prelude::*;
-use embedded_graphics::primitives::{Circle, Line, Rectangle};
+use embedded_graphics::primitives::{Circle, Rectangle, Triangle};
 use hal::i2c::{BlockingI2c, DutyCycle, Mode};
 use hal::prelude::*;
 use hal::stm32;
@@ -69,30 +69,41 @@ fn main() -> ! {
 
     disp.init().unwrap();
 
+    let yoffset = 20;
+
+    // screen outline
+    // default display size is 128x64 if you don't pass a _DisplaySize_
+    // enum to the _Builder_ struct
     disp.draw(
-        Line::new(Point::new(8, 16 + 16), Point::new(8 + 16, 16 + 16))
-            .stroke(Some(BinaryColor::On))
-            .into_iter(),
-    );
-    disp.draw(
-        Line::new(Point::new(8, 16 + 16), Point::new(8 + 8, 16))
-            .stroke(Some(BinaryColor::On))
-            .into_iter(),
-    );
-    disp.draw(
-        Line::new(Point::new(8 + 16, 16 + 16), Point::new(8 + 8, 16))
+        Rectangle::new(Point::new(0, 0), Point::new(127, 63))
             .stroke(Some(BinaryColor::On))
             .into_iter(),
     );
 
+    // triangle
     disp.draw(
-        Rectangle::new(Point::new(48, 16), Point::new(48 + 16, 16 + 16))
-            .stroke(Some(BinaryColor::On))
-            .into_iter(),
+        Triangle::new(
+            Point::new(16, 16 + yoffset),
+            Point::new(16 + 16, 16 + yoffset),
+            Point::new(16 + 8, yoffset)
+        )
+        .stroke(Some(BinaryColor::On))
+        .into_iter(),
     );
 
+    // square
     disp.draw(
-        Circle::new(Point::new(96, 16 + 8), 8)
+        Rectangle::new(
+            Point::new(52, yoffset),
+            Point::new(52 + 16, 16 + yoffset)
+        )
+        .stroke(Some(BinaryColor::On))
+        .into_iter(),
+    );
+
+    // circle
+    disp.draw(
+        Circle::new(Point::new(96, yoffset + 8), 8)
             .stroke(Some(BinaryColor::On))
             .into_iter(),
     );

--- a/examples/graphics_i2c.rs
+++ b/examples/graphics_i2c.rs
@@ -85,7 +85,7 @@ fn main() -> ! {
         Triangle::new(
             Point::new(16, 16 + yoffset),
             Point::new(16 + 16, 16 + yoffset),
-            Point::new(16 + 8, yoffset)
+            Point::new(16 + 8, yoffset),
         )
         .stroke(Some(BinaryColor::On))
         .into_iter(),
@@ -93,12 +93,9 @@ fn main() -> ! {
 
     // square
     disp.draw(
-        Rectangle::new(
-            Point::new(52, yoffset),
-            Point::new(52 + 16, 16 + yoffset)
-        )
-        .stroke(Some(BinaryColor::On))
-        .into_iter(),
+        Rectangle::new(Point::new(52, yoffset), Point::new(52 + 16, 16 + yoffset))
+            .stroke(Some(BinaryColor::On))
+            .into_iter(),
     );
 
     // circle

--- a/examples/graphics_i2c_128x32.rs
+++ b/examples/graphics_i2c_128x32.rs
@@ -2,6 +2,16 @@
 //!
 //! This example is for the STM32F103 "Blue Pill" board using I2C1.
 //!
+//! Wiring connections are as follows for a CRIUS-branded display:
+//!
+//! ```
+//!      Display -> Blue Pill
+//! (black)  GND -> GND
+//! (red)    +5V -> VCC
+//! (yellow) SDA -> PB9
+//! (green)  SCL -> PB8
+//! ```
+//!
 //! Run on a Blue Pill with `cargo run --example graphics_i2c_128x32`.
 
 #![no_std]
@@ -16,7 +26,7 @@ use cortex_m_rt::ExceptionFrame;
 use cortex_m_rt::{entry, exception};
 use embedded_graphics::pixelcolor::BinaryColor;
 use embedded_graphics::prelude::*;
-use embedded_graphics::primitives::{Circle, Line, Rectangle};
+use embedded_graphics::primitives::{Circle, Rectangle, Triangle};
 use hal::i2c::{BlockingI2c, DutyCycle, Mode};
 use hal::prelude::*;
 use hal::stm32;
@@ -63,33 +73,38 @@ fn main() -> ! {
 
     let yoffset = 8;
 
+    // screen outline
+    // - hardcode the values for the lower-right 'Point' struct
     disp.draw(
-        Line::new(
-            Point::new(8, 16 + yoffset),
-            Point::new(8 + 16, 16 + yoffset),
+        Rectangle::new(Point::new(0, 0), Point::new(127, 31))
+            .stroke(Some(BinaryColor::On))
+            .into_iter(),
+    );
+
+    // triangle
+    disp.draw(
+        Triangle::new(
+            Point::new(12, 16 + yoffset),
+            Point::new(12 + 16, 16 + yoffset),
+            Point::new(12 + 8, yoffset)
         )
         .stroke(Some(BinaryColor::On))
         .into_iter(),
     );
+
+    // square
     disp.draw(
-        Line::new(Point::new(8, 16 + yoffset), Point::new(8 + 8, yoffset))
-            .stroke(Some(BinaryColor::On))
-            .into_iter(),
-    );
-    disp.draw(
-        Line::new(Point::new(8 + 16, 16 + yoffset), Point::new(8 + 8, yoffset))
+        Rectangle::new(
+            Point::new(54, yoffset),
+            Point::new(54 + 16, 16 + yoffset)
+            )
             .stroke(Some(BinaryColor::On))
             .into_iter(),
     );
 
+    // circle
     disp.draw(
-        Rectangle::new(Point::new(48, yoffset), Point::new(48 + 16, 16 + yoffset))
-            .stroke(Some(BinaryColor::On))
-            .into_iter(),
-    );
-
-    disp.draw(
-        Circle::new(Point::new(96, yoffset + 8), 8)
+        Circle::new(Point::new(104, yoffset + 8), 8)
             .stroke(Some(BinaryColor::On))
             .into_iter(),
     );

--- a/examples/graphics_i2c_128x32.rs
+++ b/examples/graphics_i2c_128x32.rs
@@ -86,7 +86,7 @@ fn main() -> ! {
         Triangle::new(
             Point::new(12, 16 + yoffset),
             Point::new(12 + 16, 16 + yoffset),
-            Point::new(12 + 8, yoffset)
+            Point::new(12 + 8, yoffset),
         )
         .stroke(Some(BinaryColor::On))
         .into_iter(),
@@ -94,10 +94,7 @@ fn main() -> ! {
 
     // square
     disp.draw(
-        Rectangle::new(
-            Point::new(54, yoffset),
-            Point::new(54 + 16, 16 + yoffset)
-            )
+        Rectangle::new(Point::new(54, yoffset), Point::new(54 + 16, 16 + yoffset))
             .stroke(Some(BinaryColor::On))
             .into_iter(),
     );


### PR DESCRIPTION
- Use the new _Triangle_ primitive provided by _embedded_graphics_ 0.6.0-alpha.2 in the graphics demos
- Also added back the "screen outline" rectangle as seen in the original SSD1306 driver announcement blog post
- Added connection info for the *pill/display boards in the comments of examples/graphics_i2c_128x32.rs
- Tweaked the positions of the shapes a bit to "center" them

**NOTE**: I don't have a 3-wire SPI OLED board to test on, I only have a 4-wire SPI board available to me at the moment, so I was only able to test the refactored I2C demos.  The SPI OLED example (`graphics.rs`) compiles, I just can't test it 😕.  I tried grounding the CS line, but I wasn't able to get my 4-wire board to work.

If you're interested, I'd like to also add a blinkenled to the graphics examples, that way you can tell if the demo is running even if nothing shows up in the display.

128x32 I2C demo with a STM32F103C8T6 Black Pill
![black_pill_i2c_ssd1306_128x32](https://user-images.githubusercontent.com/562120/67135451-c6a88280-f1ce-11e9-9696-6228c03feaba.jpg)

128x64 I2C demo with a STM32F103C8T6 Black Pill
![black_pill_i2c_ssd1306_128x64](https://user-images.githubusercontent.com/562120/67135452-c6a88280-f1ce-11e9-9d92-90ddb751c180.jpg)

