### PR TITLE
Remove unwraps, replace with `as` coercion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- [#105](https://github.com/jamwaffles/ssd1306/pull/105) Reduce flash usage by around 400 bytes by replacing some internal `unwrap()`s with `as` coercions.
+
 ## [0.3.0-alpha.4] - 2020-02-07
 
 ### Added

--- a/src/mode/graphics.rs
+++ b/src/mode/graphics.rs
@@ -276,8 +276,6 @@ where
 }
 
 #[cfg(feature = "graphics")]
-use core::convert::TryInto;
-#[cfg(feature = "graphics")]
 use embedded_graphics::{
     drawable,
     geometry::Size,
@@ -297,16 +295,13 @@ where
         let drawable::Pixel(pos, color) = pixel;
 
         // Guard against negative values. All positive i32 values from `pos` can be represented in
-        // the `u32`s that `set_pixel()` accepts.
+        // the `u32`s that `set_pixel()` accepts...
         if pos.x < 0 || pos.y < 0 {
             return;
         }
 
-        self.set_pixel(
-            (pos.x).try_into().unwrap(),
-            (pos.y).try_into().unwrap(),
-            RawU1::from(color).into_inner(),
-        );
+        // ... which makes the `as` coercions here safe.
+        self.set_pixel(pos.x as u32, pos.y as u32, RawU1::from(color).into_inner());
     }
 
     fn size(&self) -> Size {


### PR DESCRIPTION
Hi! Thank you for helping out with SSD1306 development! Please:

- [x] Check that you've added documentation to any new methods
- [x] Rebase from `master` if you're not already up to date
- [x] Add or modify an example if there are changes to the public API
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, **Changed**, etc)
- [x] Run `rustfmt` on the project with `cargo fmt --all` - CI will not pass without this step
- [x] Check that your branch is up to date with master and that CI is passing once the PR is opened

## PR description

Removes the `unwraps()` in `DrawTarget`. Reduces `.text` section when running `cargo bloat --example graphics` from 54.4KiB to 54.0KiB.

In release mode, that goes from 13.6KiB to 13.2KiB.