### PR TITLE
Add raw random noise example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#107](https://github.com/jamwaffles/ssd1306/pull/107) Migrate from Travis to CircleCI
 - [#105](https://github.com/jamwaffles/ssd1306/pull/105) Reduce flash usage by around 400 bytes by replacing some internal `unwrap()`s with `as` coercions.
 - [#106](https://github.com/jamwaffles/ssd1306/pull/106) Optimise internals by using iterators to elide bounds checks. Should also speed up `GraphicsMode` (and `embedded-graphics` operations) with a cleaned-up `set_pixel`.
+- [#108](https://github.com/jamwaffles/ssd1306/pull/108) Add an example using `DisplayProperties.draw()` to send a raw buffer of random bytes to the display over I2C.
 
 ## [0.3.0-alpha.4] - 2020-02-07
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,11 @@ cortex-m = "0.6.1"
 cortex-m-rt = "0.6.11"
 panic-semihosting = "0.5.3"
 
+[dependencies.rand]
+version = "0.7.3"
+default-features = false
+features = [ "small_rng" ]
+
 # Turn on `bmp` feature for examples
 [dev-dependencies.embedded-graphics]
 version = "=0.6.0-alpha.3"

--- a/examples/noise_i2c.rs
+++ b/examples/noise_i2c.rs
@@ -1,0 +1,94 @@
+//! Send random raw data to the display, emulating an old untuned TV. This example `release()`s the
+//! underlying display properties struct and allows calling of the low-level `draw()` method,
+//! sending a 1024 byte buffer straight to the display.
+//!
+//! This example is for the STM32F103 "Blue Pill" board using I2C1.
+//!
+//! Wiring connections are as follows for a CRIUS-branded display:
+//!
+//! ```
+//!      Display -> Blue Pill
+//! (black)  GND -> GND
+//! (red)    +5V -> VCC
+//! (yellow) SDA -> PB9
+//! (green)  SCL -> PB8
+//! ```
+//!
+//! Run on a Blue Pill with `cargo run --example noise_i2c`. Best results when using `--release`.
+
+#![no_std]
+#![no_main]
+
+extern crate cortex_m;
+extern crate cortex_m_rt as rt;
+extern crate panic_semihosting;
+extern crate stm32f1xx_hal as hal;
+
+use cortex_m_rt::{entry, exception, ExceptionFrame};
+use embedded_graphics::{
+    pixelcolor::BinaryColor,
+    prelude::*,
+    primitives::{Circle, Rectangle, Triangle},
+    style::PrimitiveStyleBuilder,
+};
+use hal::{
+    i2c::{BlockingI2c, DutyCycle, Mode},
+    prelude::*,
+    stm32,
+};
+use rand::prelude::*;
+use ssd1306::{mode::displaymode::DisplayModeTrait, prelude::*, Builder};
+
+#[entry]
+fn main() -> ! {
+    let dp = stm32::Peripherals::take().unwrap();
+
+    let mut flash = dp.FLASH.constrain();
+    let mut rcc = dp.RCC.constrain();
+
+    let clocks = rcc.cfgr.freeze(&mut flash.acr);
+
+    let mut afio = dp.AFIO.constrain(&mut rcc.apb2);
+
+    let mut gpiob = dp.GPIOB.split(&mut rcc.apb2);
+
+    let scl = gpiob.pb8.into_alternate_open_drain(&mut gpiob.crh);
+    let sda = gpiob.pb9.into_alternate_open_drain(&mut gpiob.crh);
+
+    let i2c = BlockingI2c::i2c1(
+        dp.I2C1,
+        (scl, sda),
+        &mut afio.mapr,
+        Mode::Fast {
+            frequency: 400_000.hz(),
+            duty_cycle: DutyCycle::Ratio2to1,
+        },
+        clocks,
+        &mut rcc.apb1,
+        1000,
+        10,
+        1000,
+        1000,
+    );
+
+    let mut disp: GraphicsMode<_> = Builder::new().connect_i2c(i2c).into();
+
+    disp.init().unwrap();
+
+    let mut props = disp.release();
+
+    let mut buf = [0x00u8; 1024];
+
+    let mut rng = SmallRng::seed_from_u64(0xdead_beef_cafe_d00d);
+
+    loop {
+        rng.fill_bytes(&mut buf);
+
+        props.draw(&buf);
+    }
+}
+
+#[exception]
+fn HardFault(ef: &ExceptionFrame) -> ! {
+    panic!("{:#?}", ef);
+}


### PR DESCRIPTION
Hi! Thank you for helping out with SSD1306 development! Please:

- [x] Check that you've added documentation to any new methods
- [x] Rebase from `master` if you're not already up to date
- [x] Add or modify an example if there are changes to the public API
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, **Changed**, etc)
- [x] Run `rustfmt` on the project with `cargo fmt --all` - CI will not pass without this step
- [x] Check that your branch is up to date with master and that CI is passing once the PR is opened

## PR description

This is the result of an email discussion with @nebelgrau77 who is asking for assistance sending raw bytes to the display, without using `GraphicsMode`, etc. The example emulates an old TV with a white noise effect using random crap from the `rand` crate in no-std mode.
