### PR TITLE
Add support for 64x48px SSD1306 modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Add support for modules with a 64x48px display size.
+
 ### Changed
 
 - [#107](https://github.com/jamwaffles/ssd1306/pull/107) Migrate from Travis to CircleCI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+- [#111](https://github.com/jamwaffles/ssd1306/pull/111) Fix TerminalMode offset for smaller displays.
+
 ### Added
 
-- Add support for modules with a 64x48px display size.
+- [#111](https://github.com/jamwaffles/ssd1306/pull/111) Add support for modules with a 64x48px display size.
 
 ### Changed
 

--- a/src/displaysize.rs
+++ b/src/displaysize.rs
@@ -12,6 +12,8 @@ pub enum DisplaySize {
     Display96x16,
     /// 70 by 42 pixels
     Display72x40,
+    /// 64 by 48 pixels
+    Display64x48,
 }
 
 impl DisplaySize {
@@ -23,6 +25,7 @@ impl DisplaySize {
             DisplaySize::Display128x32 => (128, 32),
             DisplaySize::Display96x16 => (96, 16),
             DisplaySize::Display72x40 => (72, 40),
+            DisplaySize::Display64x48 => (64, 48),
         }
     }
 }

--- a/src/mode/terminal.rs
+++ b/src/mode/terminal.rs
@@ -183,6 +183,7 @@ where
             DisplaySize::Display128x32 => 64,
             DisplaySize::Display96x16 => 24,
             DisplaySize::Display72x40 => 45,
+            DisplaySize::Display64x48 => 48,
         };
 
         // Let the chip handle line wrapping so we can fill the screen with blanks faster

--- a/src/mode/terminal.rs
+++ b/src/mode/terminal.rs
@@ -191,8 +191,15 @@ where
             .change_mode(AddrMode::Horizontal)
             .terminal_err()?;
         let (display_width, display_height) = self.properties.get_dimensions();
+        let (display_x_offset, display_y_offset) = self.properties.display_offset;
         self.properties
-            .set_draw_area((0, 0), (display_width, display_height))
+            .set_draw_area(
+                (display_x_offset, display_y_offset),
+                (
+                    display_width + display_x_offset,
+                    display_height + display_y_offset,
+                ),
+            )
             .terminal_err()?;
 
         // Clear the display
@@ -304,8 +311,11 @@ where
 
     /// Reset the draw area and move pointer to the top left corner
     fn reset_pos(&mut self) -> Result<(), TerminalModeError<DI>> {
-        self.properties.set_column(0).terminal_err()?;
-        self.properties.set_row(0).terminal_err()?;
+        let (display_x_offset, display_y_offset) = self.properties.display_offset;
+        self.properties
+            .set_column(display_x_offset)
+            .terminal_err()?;
+        self.properties.set_row(display_y_offset).terminal_err()?;
         // Initialise the counter when we know it's valid
         let (display_width, display_height) = self.properties.get_dimensions();
         self.cursor = Some(Cursor::new(display_width, display_height));

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -31,6 +31,7 @@ where
             DisplaySize::Display128x32 => (0, 0),
             DisplaySize::Display96x16 => (0, 0),
             DisplaySize::Display72x40 => (28, 0),
+            DisplaySize::Display64x48 => (32, 0),
         };
 
         DisplayProperties {
@@ -71,6 +72,7 @@ where
             DisplaySize::Display128x64 => Command::ComPinConfig(true, false).send(&mut self.iface),
             DisplaySize::Display96x16 => Command::ComPinConfig(false, false).send(&mut self.iface),
             DisplaySize::Display72x40 => Command::ComPinConfig(true, false).send(&mut self.iface),
+            DisplaySize::Display64x48 => Command::ComPinConfig(true, false).send(&mut self.iface),
         }?;
 
         Command::Contrast(0x8F).send(&mut self.iface)?;


### PR DESCRIPTION
Hi! Thank you for helping out with SSD1306 development! Please:

- [ ] ~Check that you've added documentation to any new methods~
- [x] Rebase from `master` if you're not already up to date
- [ ] Add or modify an example if there are changes to the public API
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, **Changed**, etc)
- [x] Run `rustfmt` on the project with `cargo fmt --all` - CI will not pass without this step
- [x] Check that your branch is up to date with master and that CI is passing once the PR is opened

## PR description

I've got [a display that seems to use the SSD1306](https://www.aliexpress.com/item/32782787258.html). As far as I know, all that has to be added is a new DisplaySize enum and the corresponding match cases.

The HAL library for the MCU I have access to (STM32F303) currently has a bug that makes the SPI transfer LSBit-first, so I unfortunately can't submit an example that works out of the box. Would it be better to add an example that I can't test or to leave it to someone else?
