### PR TITLE
Allow reclaiming display pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Added
 
-- [#118](https://github.com/jamwaffles/ssd1306/pull/118) `DisplayModeTrait::properties()` new method that consumes the driver and returns the `DisplayProperties`
+- [#118](https://github.com/jamwaffles/ssd1306/pull/118) `DisplayModeTrait::into_properties()` new method that consumes the driver and returns the `DisplayProperties`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- [#118](https://github.com/jamwaffles/ssd1306/pull/118) `DisplayModeTrait::properties()` new method that consumes the driver and returns the `DisplayProperties`
+
 ### Changed
 
 -**(breaking)** [#119](https://github.com/jamwaffles/ssd1306/pull/119) Remove `DisplayMode` and `RawMode`
 - [#120](https://github.com/jamwaffles/ssd1306/pull/120) Update to v0.4 [`display-interface`](https://crates.io/crates/display-interface)
+- **(breaking)** [#118](https://github.com/jamwaffles/ssd1306/pull/118) Change `release` method to return the display interface instead of the `DisplayProperties`.
 - **(breaking)** [#116](https://github.com/jamwaffles/ssd1306/pull/116) Replace custom I2C and SPI interfaces by generic [`display-interface`](https://crates.io/crates/display-interface)
 - **(breaking)** [#113](https://github.com/jamwaffles/ssd1306/pull/113) Removed public `send_bounded_data` from DisplayInterface and implementations
 

--- a/examples/noise_i2c.rs
+++ b/examples/noise_i2c.rs
@@ -65,7 +65,7 @@ fn main() -> ! {
     let mut disp: GraphicsMode<_> = Builder::new().connect(interface).into();
     disp.init().unwrap();
 
-    let mut props = disp.properties();
+    let mut props = disp.into_properties();
 
     let mut buf = [0x00u8; 1024];
 

--- a/examples/noise_i2c.rs
+++ b/examples/noise_i2c.rs
@@ -1,4 +1,4 @@
-//! Send random raw data to the display, emulating an old untuned TV. This example `release()`s the
+//! Send random raw data to the display, emulating an old untuned TV. This example retrieves the
 //! underlying display properties struct and allows calling of the low-level `draw()` method,
 //! sending a 1024 byte buffer straight to the display.
 //!
@@ -65,7 +65,7 @@ fn main() -> ! {
     let mut disp: GraphicsMode<_> = Builder::new().connect(interface).into();
     disp.init().unwrap();
 
-    let mut props = disp.release();
+    let mut props = disp.properties();
 
     let mut buf = [0x00u8; 1024];
 

--- a/src/mode/displaymode.rs
+++ b/src/mode/displaymode.rs
@@ -3,10 +3,37 @@
 use crate::properties::DisplayProperties;
 
 /// Trait with core functionality for display mode switching
-pub trait DisplayModeTrait<DI> {
+pub trait DisplayModeTrait<DI>: Sized {
     /// Allocate all required data and initialise display for mode
     fn new(properties: DisplayProperties<DI>) -> Self;
 
-    /// Release resources for reuse with different mode
-    fn release(self) -> DisplayProperties<DI>;
+    /// Deconstruct object and retrieve DisplayProperties
+    fn properties(self) -> DisplayProperties<DI>;
+
+    /// Release display interface
+    fn release(self) -> DI {
+        self.properties().release()
+    }
+}
+
+impl<MODE> DisplayMode<MODE> {
+    /// Setup display to run in requested mode
+    pub fn new<DI>(properties: DisplayProperties<DI>) -> Self
+    where
+        DI: WriteOnlyDataCommand,
+        MODE: DisplayModeTrait<DI>,
+    {
+        DisplayMode(MODE::new(properties))
+    }
+
+    /// Change into any mode implementing DisplayModeTrait
+    // TODO: Figure out how to stay as generic DisplayMode but act as particular mode
+    pub fn into<DI, NMODE: DisplayModeTrait<DI>>(self) -> NMODE
+    where
+        DI: WriteOnlyDataCommand,
+        MODE: DisplayModeTrait<DI>,
+    {
+        let properties = self.0.properties();
+        NMODE::new(properties)
+    }
 }

--- a/src/mode/displaymode.rs
+++ b/src/mode/displaymode.rs
@@ -8,11 +8,11 @@ pub trait DisplayModeTrait<DI>: Sized {
     fn new(properties: DisplayProperties<DI>) -> Self;
 
     /// Deconstruct object and retrieve DisplayProperties
-    fn properties(self) -> DisplayProperties<DI>;
+    fn into_properties(self) -> DisplayProperties<DI>;
 
     /// Release display interface
     fn release(self) -> DI {
-        self.properties().release()
+        self.into_properties().release()
     }
 }
 
@@ -33,7 +33,7 @@ impl<MODE> DisplayMode<MODE> {
         DI: WriteOnlyDataCommand,
         MODE: DisplayModeTrait<DI>,
     {
-        let properties = self.0.properties();
+        let properties = self.0.into_properties();
         NMODE::new(properties)
     }
 }

--- a/src/mode/displaymode.rs
+++ b/src/mode/displaymode.rs
@@ -15,25 +15,3 @@ pub trait DisplayModeTrait<DI>: Sized {
         self.into_properties().release()
     }
 }
-
-impl<MODE> DisplayMode<MODE> {
-    /// Setup display to run in requested mode
-    pub fn new<DI>(properties: DisplayProperties<DI>) -> Self
-    where
-        DI: WriteOnlyDataCommand,
-        MODE: DisplayModeTrait<DI>,
-    {
-        DisplayMode(MODE::new(properties))
-    }
-
-    /// Change into any mode implementing DisplayModeTrait
-    // TODO: Figure out how to stay as generic DisplayMode but act as particular mode
-    pub fn into<DI, NMODE: DisplayModeTrait<DI>>(self) -> NMODE
-    where
-        DI: WriteOnlyDataCommand,
-        MODE: DisplayModeTrait<DI>,
-    {
-        let properties = self.0.into_properties();
-        NMODE::new(properties)
-    }
-}

--- a/src/mode/graphics.rs
+++ b/src/mode/graphics.rs
@@ -87,8 +87,8 @@ impl<DI> DisplayModeTrait<DI> for GraphicsMode<DI> {
         }
     }
 
-    /// Release all resources used by GraphicsMode
-    fn release(self) -> DisplayProperties<DI> {
+    /// Release display interface used by TerminalMode
+    fn properties(self) -> DisplayProperties<DI> {
         self.properties
     }
 }

--- a/src/mode/graphics.rs
+++ b/src/mode/graphics.rs
@@ -88,7 +88,7 @@ impl<DI> DisplayModeTrait<DI> for GraphicsMode<DI> {
     }
 
     /// Release display interface used by TerminalMode
-    fn properties(self) -> DisplayProperties<DI> {
+    fn into_properties(self) -> DisplayProperties<DI> {
         self.properties
     }
 }

--- a/src/mode/graphics.rs
+++ b/src/mode/graphics.rs
@@ -87,7 +87,7 @@ impl<DI> DisplayModeTrait<DI> for GraphicsMode<DI> {
         }
     }
 
-    /// Release display interface used by TerminalMode
+    /// Release display interface used by `GraphicsMode`
     fn into_properties(self) -> DisplayProperties<DI> {
         self.properties
     }

--- a/src/mode/terminal.rs
+++ b/src/mode/terminal.rs
@@ -153,8 +153,8 @@ where
         }
     }
 
-    /// Release all resources used by TerminalMode
-    fn release(self) -> DisplayProperties<DI> {
+    /// Release display interface used by TerminalMode
+    fn properties(self) -> DisplayProperties<DI> {
         self.properties
     }
 }

--- a/src/mode/terminal.rs
+++ b/src/mode/terminal.rs
@@ -154,7 +154,7 @@ where
     }
 
     /// Release display interface used by TerminalMode
-    fn properties(self) -> DisplayProperties<DI> {
+    fn into_properties(self) -> DisplayProperties<DI> {
         self.properties
     }
 }

--- a/src/mode/terminal.rs
+++ b/src/mode/terminal.rs
@@ -153,7 +153,7 @@ where
         }
     }
 
-    /// Release display interface used by TerminalMode
+    /// Release display interface used by `TerminalMode`
     fn into_properties(self) -> DisplayProperties<DI> {
         self.properties
     }

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -18,8 +18,6 @@ pub struct DisplayProperties<DI> {
 }
 
 impl<DI> DisplayProperties<DI>
-where
-    DI: WriteOnlyDataCommand,
 {
     /// Create new DisplayProperties instance
     pub fn new(
@@ -48,7 +46,12 @@ where
     pub fn release(self) -> DI {
         self.iface
     }
+}
 
+impl<DI> DisplayProperties<DI>
+where
+    DI: WriteOnlyDataCommand,
+{
     /// Initialise the display in column mode (i.e. a byte walks down a column of 8 pixels) with
     /// column 0 on the left and column _(display_width - 1)_ on the right.
     pub fn init_column_mode(&mut self) -> Result<(), DisplayError> {

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -17,8 +17,7 @@ pub struct DisplayProperties<DI> {
     addr_mode: AddrMode,
 }
 
-impl<DI> DisplayProperties<DI>
-{
+impl<DI> DisplayProperties<DI> {
     /// Create new DisplayProperties instance
     pub fn new(
         iface: DI,


### PR DESCRIPTION
- [X] Check that you've added documentation to any new methods
- [x] Rebase from `master` if you're not already up to date
- [x] Add or modify an example if there are changes to the public API
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, **Changed**, etc)
- [x] Run `rustfmt` on the project with `cargo fmt --all` - CI will not pass without this step
- [x] Check that your branch is up to date with master and that CI is passing once the PR is opened

## PR description

Hi!

I have a device that can physically cut supply to the display. In order to do that, I must ensure that the pins are floating or low, so I must be able to deconstruct the display driver to reclaim the pins.

This is a no-brainer implementation of the above functionality. Any feedback is welcome, if there is a better place to do this, or if the feature is already there but I'm blind. I've also bumped the display-interface dependencies because I rely on those as well.

Other todo items will be checked once this PR can get a green light.

Thank you :) 
