### PR TITLE
Clean up graphics mode

### DIFF
--- a/src/mode/graphics.rs
+++ b/src/mode/graphics.rs
@@ -96,6 +96,16 @@ impl<DI> GraphicsMode<DI>
 where
     DI: WriteOnlyDataCommand,
 {
+    /// Resets the area where the framebuffer was modified.
+    fn reset_dirty_area(&mut self) {
+        //  min > max means no set_pixel calls were made so far
+        self.min_x = 255;
+        self.max_x = 0;
+
+        self.min_y = 255;
+        self.max_y = 0;
+    }
+
     /// Clear the display buffer. You need to call `disp.flush()` for any effect on the screen
     pub fn clear(&mut self) {
         self.buffer = [0; 1024];
@@ -112,7 +122,9 @@ where
     /// This only updates the parts of the display that have changed since the last flush.
     pub fn flush(&mut self) -> Result<(), DisplayError> {
         // Nothing to do if no pixels have changed since the last update
-        if self.max_x < self.min_x || self.max_y < self.min_y {
+        // It's enough to check one of the dimensions because both are set to valid values by the
+        // first set_pixel call.
+        if self.max_x < self.min_x {
             return Ok(());
         }
 
@@ -131,10 +143,7 @@ where
             }
         };
 
-        self.min_x = width - 1;
-        self.max_x = 0;
-        self.min_y = width - 1;
-        self.max_y = 0;
+        self.reset_dirty_area();
 
         // Compensate for any offset in the physical display. For example, the 72x40 display has an
         // offset of (28, 0) pixels.


### PR DESCRIPTION
Extract resetting of the dirty area - use constants, since the actual values are irrelevant, only their relation is important for flush to return early

Remove redundant checks and min/max calls - assuming width/height is always divisible by 8, set_pixel will make sure max_x and max_y is in the valid range

Hi! Thank you for helping out with SSD1306 development! Please:

- [x] Check that you've added documentation to any new methods
- [x] Rebase from `master` if you're not already up to date
~- [ ] Add or modify an example if there are changes to the public API~
~- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, **Changed**, etc)~ No visible changes
- [x] Run `rustfmt` on the project with `cargo fmt --all` - CI will not pass without this step
- [x] Check that your branch is up to date with master and that CI is passing once the PR is opened

## PR description

This needs some double checking because my understanding may be incorrect.

Closes #122 but that is not a bug; may result in a negligible amount of perf gain (some checks per frame).
