### PR TITLE
Different GraphicsMode optimization options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 
+- [#124](https://github.com/jamwaffles/ssd1306/pull/124) Added type parameter to optimize `GraphicsMode` for draw speed instead of flush time.
 - [#121](https://github.com/jamwaffles/ssd1306/pull/121) Added brightness control with the `set_brightness()` method.
 - [#118](https://github.com/jamwaffles/ssd1306/pull/118) `DisplayModeTrait::into_properties()` new method that consumes the driver and returns the `DisplayProperties`
 


### PR DESCRIPTION
Hi! Thank you for helping out with SSD1306 development! Please:

- [ ] Check that you've added documentation to any new methods
- [ ] Rebase from `master` if you're not already up to date
- [ ] Add or modify an example if there are changes to the public API
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, **Changed**, etc)
- [ ] Run `rustfmt` on the project with `cargo fmt --all` - CI will not pass without this step
- [ ] Check that your branch is up to date with master and that CI is passing once the PR is opened

## PR description

In my use case, I'm using the display on an 8MHz SPI connection, which means a flush is around 1ms. This allows me to switch the partial update to a full update, and basically eliminate tracking of the dirty area.

I still need to benchmark this to see if there is any point in adding the extra complexity, but I wanted to open this draft to hear some of your thoughts on the matter.

By default, the implementation uses the old dirty area tracking method with the partial screen update, so it's hopefully backwards compatible.
