### PR TITLE
Type-level display size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Changed
 
+- **(breaking)** [#125](https://github.com/jamwaffles/ssd1306/pull/125) Redesigned display size handling.
 - **(breaking)** [#126](https://github.com/jamwaffles/ssd1306/pull/126) Moved `reset` method to `DisplayModeTrait`. If the prelude is not used, add either `use ssd1306::prelude::*` or `ssd1306::mode::displaymode::DisplayModeTrait` to your imports.
 - **(breaking)** [#119](https://github.com/jamwaffles/ssd1306/pull/119) Remove `DisplayMode` and `RawMode`
 - [#120](https://github.com/jamwaffles/ssd1306/pull/120) Update to v0.4 [`display-interface`](https://crates.io/crates/display-interface)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ embedded-hal = "0.2.3"
 display-interface = "0.4"
 display-interface-i2c = "0.4"
 display-interface-spi = "0.4"
+typenum = "1.12.0"
 
 [dependencies.embedded-graphics]
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ display-interface = "0.4"
 display-interface-i2c = "0.4"
 display-interface-spi = "0.4"
 typenum = "1.12.0"
+generic-array = "0.14.2"
 
 [dependencies.embedded-graphics]
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ embedded-hal = "0.2.3"
 display-interface = "0.4"
 display-interface-i2c = "0.4"
 display-interface-spi = "0.4"
-typenum = "1.12.0"
 generic-array = "0.14.2"
 
 [dependencies.embedded-graphics]

--- a/examples/graphics_i2c_128x32.rs
+++ b/examples/graphics_i2c_128x32.rs
@@ -66,7 +66,7 @@ fn main() -> ! {
 
     let interface = I2CDIBuilder::new().init(i2c);
     let mut disp: GraphicsMode<_, _> = Builder::new()
-        .size::<DisplaySize128x32>()
+        .size(DisplaySize128x32)
         .connect(interface)
         .into();
     disp.init().unwrap();

--- a/examples/graphics_i2c_128x32.rs
+++ b/examples/graphics_i2c_128x32.rs
@@ -65,8 +65,8 @@ fn main() -> ! {
     );
 
     let interface = I2CDIBuilder::new().init(i2c);
-    let mut disp: GraphicsMode<_> = Builder::new()
-        .size(DisplaySize::Display128x32)
+    let mut disp: GraphicsMode<_, _> = Builder::new()
+        .size::<DisplaySize128x32>()
         .connect(interface)
         .into();
     disp.init().unwrap();

--- a/examples/graphics_i2c_72x40.rs
+++ b/examples/graphics_i2c_72x40.rs
@@ -66,7 +66,7 @@ fn main() -> ! {
 
     let interface = I2CDIBuilder::new().init(i2c);
     let mut disp: GraphicsMode<_, _> = Builder::new()
-        .size::<DisplaySize72x40>()
+        .size(DisplaySize72x40)
         .connect(interface)
         .into();
     disp.init().unwrap();

--- a/examples/graphics_i2c_72x40.rs
+++ b/examples/graphics_i2c_72x40.rs
@@ -65,8 +65,8 @@ fn main() -> ! {
     );
 
     let interface = I2CDIBuilder::new().init(i2c);
-    let mut disp: GraphicsMode<_> = Builder::new()
-        .size(DisplaySize::Display72x40)
+    let mut disp: GraphicsMode<_, _> = Builder::new()
+        .size::<DisplaySize72x40>()
         .connect(interface)
         .into();
     disp.init().unwrap();

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -58,15 +58,13 @@
 
 use display_interface::WriteOnlyDataCommand;
 
-use crate::{
-    displayrotation::DisplayRotation, displaysize::*, properties::DisplayProperties,
-};
+use crate::{displayrotation::DisplayRotation, displaysize::*, properties::DisplayProperties};
 
 /// Builder struct. Driver options and interface are set using its methods.
 #[derive(Clone, Copy)]
-pub struct Builder<DSIZE=DisplaySize128x64>
+pub struct Builder<DSIZE = DisplaySize128x64>
 where
-    DSIZE: DisplaySize
+    DSIZE: DisplaySize,
 {
     rotation: DisplayRotation,
     _size: core::marker::PhantomData<DSIZE>,
@@ -83,7 +81,7 @@ where
 
 impl<DSIZE> Builder<DSIZE>
 where
-    DSIZE: DisplaySize
+    DSIZE: DisplaySize,
 {
     /// Create new builder with a default size of 128 x 64 pixels and no rotation.
     pub fn new() -> Self {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -33,7 +33,7 @@
 //! let interface = I2CDIBuilder::new().init(i2c);
 //! Builder::new()
 //!     .with_rotation(DisplayRotation::Rotate180)
-//!     .size(DisplaySize::Display128x32)
+//!     .size::<DisplaySize128x32>()
 //!     .connect(interface);
 //! ```
 //!

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -70,19 +70,13 @@ where
     _size: core::marker::PhantomData<DSIZE>,
 }
 
-impl<DSIZE> Default for Builder<DSIZE>
-where
-    DSIZE: DisplaySize,
-{
+impl Default for Builder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<DSIZE> Builder<DSIZE>
-where
-    DSIZE: DisplaySize,
-{
+impl Builder {
     /// Create new builder with a default size of 128 x 64 pixels and no rotation.
     pub fn new() -> Self {
         Self {
@@ -90,6 +84,12 @@ where
             _size: core::marker::PhantomData,
         }
     }
+}
+
+impl<DSIZE> Builder<DSIZE>
+where
+    DSIZE: DisplaySize,
+{
 
     /// Set the size of the display. Supported sizes are defined by [DisplaySize].
     pub fn size<SIZE: DisplaySize>(self) -> Builder<SIZE> {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -33,7 +33,7 @@
 //! let interface = I2CDIBuilder::new().init(i2c);
 //! Builder::new()
 //!     .with_rotation(DisplayRotation::Rotate180)
-//!     .size::<DisplaySize128x32>()
+//!     .size(DisplaySize128x32)
 //!     .connect(interface);
 //! ```
 //!
@@ -66,8 +66,8 @@ pub struct Builder<DSIZE = DisplaySize128x64>
 where
     DSIZE: DisplaySize,
 {
+    size: DSIZE,
     rotation: DisplayRotation,
-    _size: core::marker::PhantomData<DSIZE>,
 }
 
 impl Default for Builder {
@@ -80,8 +80,8 @@ impl Builder {
     /// Create new builder with a default size of 128 x 64 pixels and no rotation.
     pub fn new() -> Self {
         Self {
+            size: DisplaySize128x64,
             rotation: DisplayRotation::Rotate0,
-            _size: core::marker::PhantomData,
         }
     }
 }
@@ -91,10 +91,10 @@ where
     DSIZE: DisplaySize,
 {
     /// Set the size of the display. Supported sizes are defined by [DisplaySize].
-    pub fn size<SIZE: DisplaySize>(self) -> Builder<SIZE> {
+    pub fn size<S: DisplaySize>(self, size: S) -> Builder<S> {
         Builder {
+            size,
             rotation: self.rotation,
-            _size: core::marker::PhantomData,
         }
     }
 
@@ -112,7 +112,7 @@ where
     where
         I: WriteOnlyDataCommand,
     {
-        DisplayProperties::new(interface, self.rotation)
+        DisplayProperties::new(interface, self.size, self.rotation)
     }
 }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -31,7 +31,21 @@
 //! use ssd1306::{prelude::*, Builder, I2CDIBuilder};
 //!
 //! let interface = I2CDIBuilder::new().init(i2c);
-//! Builder::new()
+//! let di: DisplayProperties<_> = Builder::new()
+//!     .with_rotation(DisplayRotation::Rotate180)
+//!     .connect(interface);
+//! ```
+//!
+//! When using a display other than the 128 x 64, you need to specify the display size in the
+//! second type parameter:
+//!
+//! ```rust
+//! # use ssd1306::test_helpers::{PinStub, I2cStub};
+//! # let i2c = I2cStub;
+//! use ssd1306::{prelude::*, Builder, I2CDIBuilder};
+//!
+//! let interface = I2CDIBuilder::new().init(i2c);
+//! let di: DisplayProperties<_, _> = Builder::new()
 //!     .with_rotation(DisplayRotation::Rotate180)
 //!     .size(DisplaySize128x32)
 //!     .connect(interface);

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -90,7 +90,6 @@ impl<DSIZE> Builder<DSIZE>
 where
     DSIZE: DisplaySize,
 {
-
     /// Set the size of the display. Supported sizes are defined by [DisplaySize].
     pub fn size<SIZE: DisplaySize>(self) -> Builder<SIZE> {
         Builder {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -36,8 +36,9 @@
 //!     .connect(interface);
 //! ```
 //!
-//! When using a display other than the 128 x 64, you need to specify the display size in the
-//! second type parameter:
+//! The builder defaults to a display size of 128 x 64px. To use a display with a different size,
+//! call the [`size`](#method.size) method. Supported sizes can be found in the
+//! [`displaysize`](../displaysize/index.html) module or in the [prelude](../prelude/index.html).
 //!
 //! ```rust
 //! # use ssd1306::test_helpers::{PinStub, I2cStub};

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,3 +1,5 @@
+//! Display commands.
+
 // Shamefully taken from https://github.com/EdgewaterDevelopment/rust-ssd1306
 
 use display_interface::{DataFormat::U8, DisplayError, WriteOnlyDataCommand};
@@ -5,7 +7,7 @@ use display_interface::{DataFormat::U8, DisplayError, WriteOnlyDataCommand};
 /// SSD1306 Commands
 
 /// Commands
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 #[allow(dead_code)]
 pub enum Command {
     /// Set contrast. Higher number is higher contrast. Default = 0x7F

--- a/src/displaysize.rs
+++ b/src/displaysize.rs
@@ -1,13 +1,15 @@
 //! Display size
 
+use generic_array::ArrayLength;
 use super::command::Command;
-use typenum::{Unsigned, U0, U16, U28, U32, U40, U48, U64, U72, U96, U128};
+use typenum::{Unsigned, U0, U16, U28, U32, U40, U48, U64, U72, U96, U128, U192, U360, U384, U512, U1024};
 
 pub trait DisplaySize {
     type Width: Unsigned;
     type Height: Unsigned;
     type OffsetX: Unsigned;
     type OffsetY: Unsigned;
+    type BufferSize: ArrayLength<u8>;
 
     fn ComPinConfig() -> Command;
 }
@@ -18,6 +20,7 @@ impl DisplaySize for DisplaySize128x64 {
     type Height = U64;
     type OffsetX = U0;
     type OffsetY = U0;
+    type BufferSize = U1024;
 
     fn ComPinConfig() -> Command {
         Command::ComPinConfig(true, false)
@@ -30,6 +33,7 @@ impl DisplaySize for DisplaySize128x32 {
     type Height = U32;
     type OffsetX = U0;
     type OffsetY = U0;
+    type BufferSize = U512;
 
     fn ComPinConfig() -> Command {
         Command::ComPinConfig(false, false)
@@ -42,6 +46,7 @@ impl DisplaySize for DisplaySize96x16 {
     type Height = U16;
     type OffsetX = U0;
     type OffsetY = U0;
+    type BufferSize = U192;
 
     fn ComPinConfig() -> Command {
         Command::ComPinConfig(false, false)
@@ -54,6 +59,7 @@ impl DisplaySize for DisplaySize72x40 {
     type Height = U40;
     type OffsetX = U28;
     type OffsetY = U0;
+    type BufferSize = U360;
 
     fn ComPinConfig() -> Command {
         Command::ComPinConfig(true, false)
@@ -66,6 +72,7 @@ impl DisplaySize for DisplaySize64x48 {
     type Height = U48;
     type OffsetX = U32;
     type OffsetY = U0;
+    type BufferSize = U384;
 
     fn ComPinConfig() -> Command {
         Command::ComPinConfig(true, false)

--- a/src/displaysize.rs
+++ b/src/displaysize.rs
@@ -12,7 +12,6 @@ use typenum::{U1024, U192, U360, U384, U512};
 /// This trait describes information related to a particular display.
 /// This includes resolution, offset and framebuffer size.
 pub trait DisplaySize {
-
     /// Width in pixels
     const WIDTH: u8;
 

--- a/src/displaysize.rs
+++ b/src/displaysize.rs
@@ -2,81 +2,73 @@
 
 use super::command::Command;
 use generic_array::ArrayLength;
-use typenum::{
-    Unsigned, U0, U1024, U128, U16, U192, U28, U32, U360, U384, U40, U48, U512, U64, U72, U96,
-};
+use typenum::{U1024, U192, U360, U384, U512};
 
 pub trait DisplaySize {
-    type Width: Unsigned;
-    type Height: Unsigned;
-    type OffsetX: Unsigned;
-    type OffsetY: Unsigned;
+    const WIDTH: u8;
+    const HEIGHT: u8;
+    const OFFSETX: u8 = 0;
+    const OFFSETY: u8 = 0;
     type BufferSize: ArrayLength<u8>;
 
-    fn ComPinConfig() -> Command;
+    fn com_pin_config() -> Command;
 }
 
 pub struct DisplaySize128x64;
 impl DisplaySize for DisplaySize128x64 {
-    type Width = U128;
-    type Height = U64;
-    type OffsetX = U0;
-    type OffsetY = U0;
+    const WIDTH: u8 = 128;
+    const HEIGHT: u8 = 64;
     type BufferSize = U1024;
 
-    fn ComPinConfig() -> Command {
+    fn com_pin_config() -> Command {
         Command::ComPinConfig(true, false)
     }
 }
 
 pub struct DisplaySize128x32;
 impl DisplaySize for DisplaySize128x32 {
-    type Width = U128;
-    type Height = U32;
-    type OffsetX = U0;
-    type OffsetY = U0;
+    const WIDTH: u8 = 128;
+    const HEIGHT: u8 = 32;
     type BufferSize = U512;
 
-    fn ComPinConfig() -> Command {
+    fn com_pin_config() -> Command {
         Command::ComPinConfig(false, false)
     }
 }
 
 pub struct DisplaySize96x16;
 impl DisplaySize for DisplaySize96x16 {
-    type Width = U96;
-    type Height = U16;
-    type OffsetX = U0;
-    type OffsetY = U0;
+    const WIDTH: u8 = 96;
+    const HEIGHT: u8 = 16;
     type BufferSize = U192;
 
-    fn ComPinConfig() -> Command {
+    fn com_pin_config() -> Command {
         Command::ComPinConfig(false, false)
     }
 }
 
 pub struct DisplaySize72x40;
 impl DisplaySize for DisplaySize72x40 {
-    type Width = U72;
-    type Height = U40;
-    type OffsetX = U28;
-    type OffsetY = U0;
+    const WIDTH: u8 = 72;
+    const HEIGHT: u8 = 40;
+    const OFFSETX: u8 = 28;
+    const OFFSETY: u8 = 0;
     type BufferSize = U360;
 
-    fn ComPinConfig() -> Command {
+    fn com_pin_config() -> Command {
         Command::ComPinConfig(true, false)
     }
 }
 
 pub struct DisplaySize64x48;
 impl DisplaySize for DisplaySize64x48 {
-    type Width = U64;
-    type Height = U48;
-    type OffsetX = U32;
-    type OffsetY = U0;
+    const WIDTH: u8 = 64;
+    const HEIGHT: u8 = 48;
+    const OFFSETX: u8 = 32;
+    const OFFSETY: u8 = 0;
     type BufferSize = U384;
 
-    fn ComPinConfig() -> Command {
+    fn com_pin_config() -> Command {
         Command::ComPinConfig(true, false)
     }
 }

--- a/src/displaysize.rs
+++ b/src/displaysize.rs
@@ -3,6 +3,7 @@
 // These are not instantiated, so no need to implement Copy
 #![allow(missing_copy_implementations)]
 
+use display_interface::{DisplayError, WriteOnlyDataCommand};
 use super::command::Command;
 use generic_array::ArrayLength;
 use typenum::{U1024, U192, U360, U384, U512};
@@ -28,11 +29,11 @@ pub trait DisplaySize {
     /// width * height / 8
     type BufferSize: ArrayLength<u8>;
 
-    /// Returns the command to set up com hardware configuration
+    /// Send resolution-dependent configuration to the display
     ///
     /// See [`Command::ComPinConfig`](../command/enum.Command.html#variant.ComPinConfig)
     /// for more information
-    fn com_pin_config() -> Command;
+    fn configure(iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError>;
 }
 
 /// Size information for the common 128x64 variants
@@ -42,8 +43,8 @@ impl DisplaySize for DisplaySize128x64 {
     const HEIGHT: u8 = 64;
     type BufferSize = U1024;
 
-    fn com_pin_config() -> Command {
-        Command::ComPinConfig(true, false)
+    fn configure(iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
+        Command::ComPinConfig(true, false).send(iface)
     }
 }
 
@@ -54,8 +55,8 @@ impl DisplaySize for DisplaySize128x32 {
     const HEIGHT: u8 = 32;
     type BufferSize = U512;
 
-    fn com_pin_config() -> Command {
-        Command::ComPinConfig(false, false)
+    fn configure(iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
+        Command::ComPinConfig(false, false).send(iface)
     }
 }
 
@@ -66,8 +67,8 @@ impl DisplaySize for DisplaySize96x16 {
     const HEIGHT: u8 = 16;
     type BufferSize = U192;
 
-    fn com_pin_config() -> Command {
-        Command::ComPinConfig(false, false)
+    fn configure(iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
+        Command::ComPinConfig(false, false).send(iface)
     }
 }
 
@@ -80,8 +81,8 @@ impl DisplaySize for DisplaySize72x40 {
     const OFFSETY: u8 = 0;
     type BufferSize = U360;
 
-    fn com_pin_config() -> Command {
-        Command::ComPinConfig(true, false)
+    fn configure(iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
+        Command::ComPinConfig(true, false).send(iface)
     }
 }
 
@@ -94,7 +95,7 @@ impl DisplaySize for DisplaySize64x48 {
     const OFFSETY: u8 = 0;
     type BufferSize = U384;
 
-    fn com_pin_config() -> Command {
-        Command::ComPinConfig(true, false)
+    fn configure(iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
+        Command::ComPinConfig(true, false).send(iface)
     }
 }

--- a/src/displaysize.rs
+++ b/src/displaysize.rs
@@ -1,8 +1,10 @@
 //! Display size
 
-use generic_array::ArrayLength;
 use super::command::Command;
-use typenum::{Unsigned, U0, U16, U28, U32, U40, U48, U64, U72, U96, U128, U192, U360, U384, U512, U1024};
+use generic_array::ArrayLength;
+use typenum::{
+    Unsigned, U0, U1024, U128, U16, U192, U28, U32, U360, U384, U40, U48, U512, U64, U72, U96,
+};
 
 pub trait DisplaySize {
     type Width: Unsigned;

--- a/src/displaysize.rs
+++ b/src/displaysize.rs
@@ -1,19 +1,42 @@
 //! Display size
 
+// These are not instantiated, so no need to implement Copy
+#![allow(missing_copy_implementations)]
+
 use super::command::Command;
 use generic_array::ArrayLength;
 use typenum::{U1024, U192, U360, U384, U512};
 
+/// Display information
+///
+/// This trait describes information related to a particular display.
+/// This includes resolution, offset and framebuffer size.
 pub trait DisplaySize {
+
+    /// Width in pixels
     const WIDTH: u8;
+
+    /// Height in pixels
     const HEIGHT: u8;
+
+    /// Horizontal offset in pixels
     const OFFSETX: u8 = 0;
+
+    /// Vertical offset in pixels
     const OFFSETY: u8 = 0;
+
+    /// Size of framebuffer. Because the display is monocrome, this is
+    /// width * height / 8
     type BufferSize: ArrayLength<u8>;
 
+    /// Returns the command to set up com hardware configuration
+    ///
+    /// See [`Command::ComPinConfig`](../command/enum.Command.html#variant.ComPinConfig)
+    /// for more information
     fn com_pin_config() -> Command;
 }
 
+/// Size information for the common 128x64 variants
 pub struct DisplaySize128x64;
 impl DisplaySize for DisplaySize128x64 {
     const WIDTH: u8 = 128;
@@ -25,6 +48,7 @@ impl DisplaySize for DisplaySize128x64 {
     }
 }
 
+/// Size information for the common 128x32 variants
 pub struct DisplaySize128x32;
 impl DisplaySize for DisplaySize128x32 {
     const WIDTH: u8 = 128;
@@ -36,6 +60,7 @@ impl DisplaySize for DisplaySize128x32 {
     }
 }
 
+/// Size information for the common 96x16 variants
 pub struct DisplaySize96x16;
 impl DisplaySize for DisplaySize96x16 {
     const WIDTH: u8 = 96;
@@ -47,6 +72,7 @@ impl DisplaySize for DisplaySize96x16 {
     }
 }
 
+/// Size information for the common 72x40 variants
 pub struct DisplaySize72x40;
 impl DisplaySize for DisplaySize72x40 {
     const WIDTH: u8 = 72;
@@ -60,6 +86,7 @@ impl DisplaySize for DisplaySize72x40 {
     }
 }
 
+/// Size information for the common 64x48 variants
 pub struct DisplaySize64x48;
 impl DisplaySize for DisplaySize64x48 {
     const WIDTH: u8 = 64;

--- a/src/displaysize.rs
+++ b/src/displaysize.rs
@@ -1,12 +1,11 @@
 //! Display size
 
-// No need to implement Copy
-#![allow(missing_copy_implementations)]
-
 use super::command::Command;
 use display_interface::{DisplayError, WriteOnlyDataCommand};
-use generic_array::ArrayLength;
-use typenum::{U1024, U192, U360, U384, U512};
+use generic_array::{
+    typenum::{U1024, U192, U360, U384, U512},
+    ArrayLength,
+};
 
 /// Display information
 ///
@@ -37,6 +36,7 @@ pub trait DisplaySize {
 }
 
 /// Size information for the common 128x64 variants
+#[derive(Debug, Copy, Clone)]
 pub struct DisplaySize128x64;
 impl DisplaySize for DisplaySize128x64 {
     const WIDTH: u8 = 128;
@@ -49,6 +49,7 @@ impl DisplaySize for DisplaySize128x64 {
 }
 
 /// Size information for the common 128x32 variants
+#[derive(Debug, Copy, Clone)]
 pub struct DisplaySize128x32;
 impl DisplaySize for DisplaySize128x32 {
     const WIDTH: u8 = 128;
@@ -61,6 +62,7 @@ impl DisplaySize for DisplaySize128x32 {
 }
 
 /// Size information for the common 96x16 variants
+#[derive(Debug, Copy, Clone)]
 pub struct DisplaySize96x16;
 impl DisplaySize for DisplaySize96x16 {
     const WIDTH: u8 = 96;
@@ -73,6 +75,7 @@ impl DisplaySize for DisplaySize96x16 {
 }
 
 /// Size information for the common 72x40 variants
+#[derive(Debug, Copy, Clone)]
 pub struct DisplaySize72x40;
 impl DisplaySize for DisplaySize72x40 {
     const WIDTH: u8 = 72;
@@ -87,6 +90,7 @@ impl DisplaySize for DisplaySize72x40 {
 }
 
 /// Size information for the common 64x48 variants
+#[derive(Debug, Copy, Clone)]
 pub struct DisplaySize64x48;
 impl DisplaySize for DisplaySize64x48 {
     const WIDTH: u8 = 64;

--- a/src/displaysize.rs
+++ b/src/displaysize.rs
@@ -1,31 +1,73 @@
 //! Display size
 
-// TODO: Add to prelude
-/// Display size enumeration
-#[derive(Clone, Copy)]
-pub enum DisplaySize {
-    /// 128 by 64 pixels
-    Display128x64,
-    /// 128 by 32 pixels
-    Display128x32,
-    /// 96 by 16 pixels
-    Display96x16,
-    /// 70 by 42 pixels
-    Display72x40,
-    /// 64 by 48 pixels
-    Display64x48,
+use super::command::Command;
+use typenum::{Unsigned, U0, U16, U28, U32, U40, U48, U64, U72, U96, U128};
+
+pub trait DisplaySize {
+    type Width: Unsigned;
+    type Height: Unsigned;
+    type OffsetX: Unsigned;
+    type OffsetY: Unsigned;
+
+    fn ComPinConfig() -> Command;
 }
 
-impl DisplaySize {
-    /// Get integral dimensions from DisplaySize
-    // TODO: Use whatever vec2 impl I decide to use here
-    pub fn dimensions(self) -> (u8, u8) {
-        match self {
-            DisplaySize::Display128x64 => (128, 64),
-            DisplaySize::Display128x32 => (128, 32),
-            DisplaySize::Display96x16 => (96, 16),
-            DisplaySize::Display72x40 => (72, 40),
-            DisplaySize::Display64x48 => (64, 48),
-        }
+pub struct DisplaySize128x64;
+impl DisplaySize for DisplaySize128x64 {
+    type Width = U128;
+    type Height = U64;
+    type OffsetX = U0;
+    type OffsetY = U0;
+
+    fn ComPinConfig() -> Command {
+        Command::ComPinConfig(true, false)
+    }
+}
+
+pub struct DisplaySize128x32;
+impl DisplaySize for DisplaySize128x32 {
+    type Width = U128;
+    type Height = U32;
+    type OffsetX = U0;
+    type OffsetY = U0;
+
+    fn ComPinConfig() -> Command {
+        Command::ComPinConfig(false, false)
+    }
+}
+
+pub struct DisplaySize96x16;
+impl DisplaySize for DisplaySize96x16 {
+    type Width = U96;
+    type Height = U16;
+    type OffsetX = U0;
+    type OffsetY = U0;
+
+    fn ComPinConfig() -> Command {
+        Command::ComPinConfig(false, false)
+    }
+}
+
+pub struct DisplaySize72x40;
+impl DisplaySize for DisplaySize72x40 {
+    type Width = U72;
+    type Height = U40;
+    type OffsetX = U28;
+    type OffsetY = U0;
+
+    fn ComPinConfig() -> Command {
+        Command::ComPinConfig(true, false)
+    }
+}
+
+pub struct DisplaySize64x48;
+impl DisplaySize for DisplaySize64x48 {
+    type Width = U64;
+    type Height = U48;
+    type OffsetX = U32;
+    type OffsetY = U0;
+
+    fn ComPinConfig() -> Command {
+        Command::ComPinConfig(true, false)
     }
 }

--- a/src/displaysize.rs
+++ b/src/displaysize.rs
@@ -1,10 +1,10 @@
 //! Display size
 
-// These are not instantiated, so no need to implement Copy
+// No need to implement Copy
 #![allow(missing_copy_implementations)]
 
-use display_interface::{DisplayError, WriteOnlyDataCommand};
 use super::command::Command;
+use display_interface::{DisplayError, WriteOnlyDataCommand};
 use generic_array::ArrayLength;
 use typenum::{U1024, U192, U360, U384, U512};
 
@@ -33,7 +33,7 @@ pub trait DisplaySize {
     ///
     /// See [`Command::ComPinConfig`](../command/enum.Command.html#variant.ComPinConfig)
     /// for more information
-    fn configure(iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError>;
+    fn configure(&self, iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError>;
 }
 
 /// Size information for the common 128x64 variants
@@ -43,7 +43,7 @@ impl DisplaySize for DisplaySize128x64 {
     const HEIGHT: u8 = 64;
     type BufferSize = U1024;
 
-    fn configure(iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
+    fn configure(&self, iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
         Command::ComPinConfig(true, false).send(iface)
     }
 }
@@ -55,7 +55,7 @@ impl DisplaySize for DisplaySize128x32 {
     const HEIGHT: u8 = 32;
     type BufferSize = U512;
 
-    fn configure(iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
+    fn configure(&self, iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
         Command::ComPinConfig(false, false).send(iface)
     }
 }
@@ -67,7 +67,7 @@ impl DisplaySize for DisplaySize96x16 {
     const HEIGHT: u8 = 16;
     type BufferSize = U192;
 
-    fn configure(iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
+    fn configure(&self, iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
         Command::ComPinConfig(false, false).send(iface)
     }
 }
@@ -81,7 +81,7 @@ impl DisplaySize for DisplaySize72x40 {
     const OFFSETY: u8 = 0;
     type BufferSize = U360;
 
-    fn configure(iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
+    fn configure(&self, iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
         Command::ComPinConfig(true, false).send(iface)
     }
 }
@@ -95,7 +95,7 @@ impl DisplaySize for DisplaySize64x48 {
     const OFFSETY: u8 = 0;
     type BufferSize = U384;
 
-    fn configure(iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
+    fn configure(&self, iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
         Command::ComPinConfig(true, false).send(iface)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,7 @@ extern crate embedded_hal as hal;
 
 pub mod brightness;
 pub mod builder;
-mod command;
+pub mod command;
 pub mod displayrotation;
 pub mod displaysize;
 pub mod mode;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,7 @@ pub mod brightness;
 pub mod builder;
 mod command;
 pub mod displayrotation;
-mod displaysize;
+pub mod displaysize;
 pub mod mode;
 pub mod prelude;
 pub mod properties;

--- a/src/mode/displaymode.rs
+++ b/src/mode/displaymode.rs
@@ -5,12 +5,12 @@ use crate::Error;
 use hal::{blocking::delay::DelayMs, digital::v2::OutputPin};
 
 /// Trait with core functionality for display mode switching
-pub trait DisplayModeTrait<DI>: Sized {
+pub trait DisplayModeTrait<DI, DSIZE>: Sized {
     /// Allocate all required data and initialise display for mode
-    fn new(properties: DisplayProperties<DI>) -> Self;
+    fn new(properties: DisplayProperties<DI, DSIZE>) -> Self;
 
     /// Deconstruct object and retrieve DisplayProperties
-    fn into_properties(self) -> DisplayProperties<DI>;
+    fn into_properties(self) -> DisplayProperties<DI, DSIZE>;
 
     /// Release display interface
     fn release(self) -> DI {

--- a/src/mode/graphics.rs
+++ b/src/mode/graphics.rs
@@ -64,6 +64,7 @@ use crate::{
     properties::DisplayProperties,
 };
 
+// TODO: Add to prelude
 /// Graphics mode handler
 pub struct GraphicsMode<DI, DSIZE = DisplaySize128x64>
 where
@@ -139,9 +140,9 @@ where
             }
         };
 
-        self.min_x = width - 1;
+        self.min_x = 255;
         self.max_x = 0;
-        self.min_y = width - 1;
+        self.min_y = 255;
         self.max_y = 0;
 
         // Tell the display to update only the part that has changed

--- a/src/mode/graphics.rs
+++ b/src/mode/graphics.rs
@@ -64,7 +64,6 @@ use crate::{
     properties::DisplayProperties,
 };
 
-// TODO: Add to prelude
 /// Graphics mode handler
 pub struct GraphicsMode<DI, DSIZE = DisplaySize128x64>
 where

--- a/src/mode/graphics.rs
+++ b/src/mode/graphics.rs
@@ -55,7 +55,7 @@
 //!
 //! [embedded_graphics]: https://crates.io/crates/embedded_graphics
 
-use crate::displaysize::DisplaySize;
+use crate::displaysize::{DisplaySize, DisplaySize128x64};
 use display_interface::{DisplayError, WriteOnlyDataCommand};
 use generic_array::GenericArray;
 use hal::{blocking::delay::DelayMs, digital::v2::OutputPin};
@@ -68,7 +68,7 @@ use crate::{
 
 // TODO: Add to prelude
 /// Graphics mode handler
-pub struct GraphicsMode<DI, DSIZE>
+pub struct GraphicsMode<DI, DSIZE=DisplaySize128x64>
 where
     DSIZE: DisplaySize,
 {

--- a/src/mode/graphics.rs
+++ b/src/mode/graphics.rs
@@ -66,7 +66,7 @@ use crate::{
 
 // TODO: Add to prelude
 /// Graphics mode handler
-pub struct GraphicsMode<DI, DSIZE=DisplaySize128x64>
+pub struct GraphicsMode<DI, DSIZE = DisplaySize128x64>
 where
     DSIZE: DisplaySize,
 {
@@ -149,14 +149,8 @@ where
         match self.properties.get_rotation() {
             DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => {
                 self.properties.set_draw_area(
-                    (
-                        disp_min_x + DSIZE::OFFSETX,
-                        disp_min_y + DSIZE::OFFSETY,
-                    ),
-                    (
-                        disp_max_x + DSIZE::OFFSETX,
-                        disp_max_y + DSIZE::OFFSETY,
-                    ),
+                    (disp_min_x + DSIZE::OFFSETX, disp_min_y + DSIZE::OFFSETY),
+                    (disp_max_x + DSIZE::OFFSETX, disp_max_y + DSIZE::OFFSETY),
                 )?;
 
                 self.properties.bounded_draw(
@@ -168,14 +162,8 @@ where
             }
             DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => {
                 self.properties.set_draw_area(
-                    (
-                        disp_min_y + DSIZE::OFFSETY,
-                        disp_min_x + DSIZE::OFFSETX,
-                    ),
-                    (
-                        disp_max_y + DSIZE::OFFSETY,
-                        disp_max_x + DSIZE::OFFSETX,
-                    ),
+                    (disp_min_y + DSIZE::OFFSETY, disp_min_x + DSIZE::OFFSETX),
+                    (disp_max_y + DSIZE::OFFSETY, disp_max_x + DSIZE::OFFSETX),
                 )?;
 
                 self.properties.bounded_draw(

--- a/src/mode/graphics.rs
+++ b/src/mode/graphics.rs
@@ -55,10 +55,11 @@
 //!
 //! [embedded_graphics]: https://crates.io/crates/embedded_graphics
 
-use generic_array::GenericArray;
-use typenum::Unsigned;
 use crate::displaysize::DisplaySize;
 use display_interface::{DisplayError, WriteOnlyDataCommand};
+use generic_array::GenericArray;
+use hal::{blocking::delay::DelayMs, digital::v2::OutputPin};
+use typenum::Unsigned;
 
 use crate::{
     brightness::Brightness, displayrotation::DisplayRotation, mode::displaymode::DisplayModeTrait,
@@ -150,8 +151,14 @@ where
         match self.properties.get_rotation() {
             DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => {
                 self.properties.set_draw_area(
-                    (disp_min_x + DSIZE::OffsetX::U8, disp_min_y + DSIZE::OffsetY::U8),
-                    (disp_max_x + DSIZE::OffsetX::U8, disp_max_y + DSIZE::OffsetY::U8),
+                    (
+                        disp_min_x + DSIZE::OffsetX::U8,
+                        disp_min_y + DSIZE::OffsetY::U8,
+                    ),
+                    (
+                        disp_max_x + DSIZE::OffsetX::U8,
+                        disp_max_y + DSIZE::OffsetY::U8,
+                    ),
                 )?;
 
                 self.properties.bounded_draw(
@@ -163,8 +170,14 @@ where
             }
             DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => {
                 self.properties.set_draw_area(
-                    (disp_min_y + DSIZE::OffsetY::U8, disp_min_x + DSIZE::OffsetX::U8),
-                    (disp_max_y + DSIZE::OffsetY::U8, disp_max_x + DSIZE::OffsetX::U8),
+                    (
+                        disp_min_y + DSIZE::OffsetY::U8,
+                        disp_min_x + DSIZE::OffsetX::U8,
+                    ),
+                    (
+                        disp_max_y + DSIZE::OffsetY::U8,
+                        disp_max_x + DSIZE::OffsetX::U8,
+                    ),
                 )?;
 
                 self.properties.bounded_draw(

--- a/src/mode/graphics.rs
+++ b/src/mode/graphics.rs
@@ -58,8 +58,6 @@
 use crate::displaysize::{DisplaySize, DisplaySize128x64};
 use display_interface::{DisplayError, WriteOnlyDataCommand};
 use generic_array::GenericArray;
-use hal::{blocking::delay::DelayMs, digital::v2::OutputPin};
-use typenum::Unsigned;
 
 use crate::{
     brightness::Brightness, displayrotation::DisplayRotation, mode::displaymode::DisplayModeTrait,
@@ -102,7 +100,7 @@ where
     }
 }
 
-impl<DI> GraphicsMode<DI>
+impl<DI, DSIZE> GraphicsMode<DI, DSIZE>
 where
     DSIZE: DisplaySize,
     DI: WriteOnlyDataCommand,
@@ -152,12 +150,12 @@ where
             DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => {
                 self.properties.set_draw_area(
                     (
-                        disp_min_x + DSIZE::OffsetX::U8,
-                        disp_min_y + DSIZE::OffsetY::U8,
+                        disp_min_x + DSIZE::OFFSETX,
+                        disp_min_y + DSIZE::OFFSETY,
                     ),
                     (
-                        disp_max_x + DSIZE::OffsetX::U8,
-                        disp_max_y + DSIZE::OffsetY::U8,
+                        disp_max_x + DSIZE::OFFSETX,
+                        disp_max_y + DSIZE::OFFSETY,
                     ),
                 )?;
 
@@ -171,12 +169,12 @@ where
             DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => {
                 self.properties.set_draw_area(
                     (
-                        disp_min_y + DSIZE::OffsetY::U8,
-                        disp_min_x + DSIZE::OffsetX::U8,
+                        disp_min_y + DSIZE::OFFSETY,
+                        disp_min_x + DSIZE::OFFSETX,
                     ),
                     (
-                        disp_max_y + DSIZE::OffsetY::U8,
-                        disp_max_x + DSIZE::OffsetX::U8,
+                        disp_max_y + DSIZE::OFFSETY,
+                        disp_max_x + DSIZE::OFFSETX,
                     ),
                 )?;
 
@@ -197,13 +195,13 @@ where
 
         let (idx, bit) = match display_rotation {
             DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => {
-                let idx = ((y as usize) / 8 * DSIZE::Width::U8 as usize) + (x as usize);
+                let idx = ((y as usize) / 8 * DSIZE::WIDTH as usize) + (x as usize);
                 let bit = y % 8;
 
                 (idx, bit)
             }
             DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => {
-                let idx = ((x as usize) / 8 * DSIZE::Width::U8 as usize) + (y as usize);
+                let idx = ((x as usize) / 8 * DSIZE::WIDTH as usize) + (y as usize);
                 let bit = x % 8;
 
                 (idx, bit)

--- a/src/mode/graphics.rs
+++ b/src/mode/graphics.rs
@@ -55,6 +55,7 @@
 //!
 //! [embedded_graphics]: https://crates.io/crates/embedded_graphics
 
+use generic_array::GenericArray;
 use typenum::Unsigned;
 use crate::displaysize::DisplaySize;
 use display_interface::{DisplayError, WriteOnlyDataCommand};
@@ -71,7 +72,7 @@ where
     DSIZE: DisplaySize,
 {
     properties: DisplayProperties<DI, DSIZE>,
-    buffer: [u8; 1024],
+    buffer: GenericArray<u8, DSIZE::BufferSize>,
     min_x: u8,
     max_x: u8,
     min_y: u8,
@@ -86,7 +87,7 @@ where
     fn new(properties: DisplayProperties<DI, DSIZE>) -> Self {
         GraphicsMode {
             properties,
-            buffer: [0; 1024],
+            buffer: GenericArray::default(),
             min_x: 255,
             max_x: 0,
             min_y: 255,
@@ -107,7 +108,7 @@ where
 {
     /// Clear the display buffer. You need to call `disp.flush()` for any effect on the screen
     pub fn clear(&mut self) {
-        self.buffer = [0; 1024];
+        self.buffer = GenericArray::default();
 
         let (width, height) = self.get_dimensions();
         self.min_x = 0;

--- a/src/mode/terminal.rs
+++ b/src/mode/terminal.rs
@@ -40,6 +40,8 @@ use crate::{
 };
 use core::{cmp::min, fmt};
 
+/// Extends the [`DisplaySize`](../../displaysize/trait.DisplaySize.html) trait
+/// to include number of characters that can fit on the display.
 pub trait TerminalDisplaySize: DisplaySize {
     /// The number of characters that can fit on the display at once (w * h / (8 * 8))
     const CHAR_NUM: u8;

--- a/src/mode/terminal.rs
+++ b/src/mode/terminal.rs
@@ -196,7 +196,6 @@ where
 {
     /// Clear the display and reset the cursor to the top left corner
     pub fn clear(&mut self) -> Result<(), TerminalModeError> {
-
         // Let the chip handle line wrapping so we can fill the screen with blanks faster
         self.properties
             .change_mode(AddrMode::Horizontal)
@@ -308,9 +307,7 @@ where
 
     /// Reset the draw area and move pointer to the top left corner
     fn reset_pos(&mut self) -> Result<(), TerminalModeError> {
-        self.properties
-            .set_column(DSIZE::OFFSETX)
-            .terminal_err()?;
+        self.properties.set_column(DSIZE::OFFSETX).terminal_err()?;
         self.properties.set_row(DSIZE::OFFSETY).terminal_err()?;
         // Initialise the counter when we know it's valid
         self.cursor = Some(Cursor::new(DSIZE::WIDTH, DSIZE::HEIGHT));

--- a/src/mode/terminal.rs
+++ b/src/mode/terminal.rs
@@ -160,7 +160,7 @@ impl<T> IntoTerminalModeResult<T> for Result<T, DisplayError> {
 
 // TODO: Add to prelude
 /// Terminal mode handler
-pub struct TerminalMode<DI, DSIZE>
+pub struct TerminalMode<DI, DSIZE = DisplaySize128x64>
 where
     DSIZE: TerminalDisplaySize,
 {

--- a/src/mode/terminal.rs
+++ b/src/mode/terminal.rs
@@ -25,8 +25,8 @@
 //! }
 //! ```
 
-use typenum::{Unsigned, U128, U64, U24, U45, U48};
 use display_interface::{DisplayError, WriteOnlyDataCommand};
+use typenum::{Unsigned, U128, U24, U45, U48, U64};
 
 use crate::{
     brightness::Brightness,
@@ -194,7 +194,6 @@ where
 {
     /// Clear the display and reset the cursor to the top left corner
     pub fn clear(&mut self) -> Result<(), TerminalModeError> {
-
         // The number of characters that can fit on the display at once (w * h / (8 * 8))
         let numchars = DSIZE::CharNum::U8;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -11,4 +11,5 @@ pub use super::{
         DisplaySize128x32, DisplaySize128x64, DisplaySize64x48, DisplaySize72x40, DisplaySize96x16,
     },
     mode::{displaymode::DisplayModeTrait, GraphicsMode, TerminalMode},
+    properties::DisplayProperties,
 };

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -7,6 +7,8 @@ pub use display_interface_spi::{SPIInterface, SPIInterfaceNoCS};
 pub use super::{
     brightness::Brightness,
     displayrotation::DisplayRotation,
-    displaysize::*,
+    displaysize::{
+        DisplaySize128x32, DisplaySize128x64, DisplaySize64x48, DisplaySize72x40, DisplaySize96x16,
+    },
     mode::{displaymode::DisplayModeTrait, GraphicsMode, TerminalMode},
 };

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -7,6 +7,6 @@ pub use display_interface_spi::{SPIInterface, SPIInterfaceNoCS};
 pub use super::{
     brightness::Brightness,
     displayrotation::DisplayRotation,
-    displaysize::DisplaySize,
+    displaysize::*,
     mode::{displaymode::DisplayModeTrait, GraphicsMode, TerminalMode},
 };

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -169,7 +169,6 @@ where
     /// #
     /// let disp = DisplayProperties::new(
     ///     interface,
-    ///     DisplaySize::Display128x64,
     ///     DisplayRotation::Rotate0,
     /// );
     /// assert_eq!(disp.get_dimensions(), (128, 64));
@@ -177,7 +176,6 @@ where
     /// # let interface = StubInterface;
     /// let rotated_disp = DisplayProperties::new(
     ///     interface,
-    ///     DisplaySize::Display128x64,
     ///     DisplayRotation::Rotate90,
     /// );
     /// assert_eq!(rotated_disp.get_dimensions(), (64, 128));

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -1,5 +1,4 @@
 //! Container to store and set display properties
-use typenum::Unsigned;
 use crate::mode::displaymode::DisplayModeTrait;
 use crate::{
     brightness::Brightness,
@@ -8,6 +7,7 @@ use crate::{
     displaysize::DisplaySize,
 };
 use display_interface::{DataFormat::U8, DisplayError, WriteOnlyDataCommand};
+use typenum::Unsigned;
 
 /// Display properties struct
 pub struct DisplayProperties<DI, DSIZE> {
@@ -22,10 +22,7 @@ where
     DSIZE: DisplaySize,
 {
     /// Create new DisplayProperties instance
-    pub fn new(
-        iface: DI,
-        display_rotation: DisplayRotation,
-    ) -> DisplayProperties<DI, DSIZE> {
+    pub fn new(iface: DI, display_rotation: DisplayRotation) -> DisplayProperties<DI, DSIZE> {
         DisplayProperties {
             iface,
             display_rotation,
@@ -42,7 +39,7 @@ impl<DI, DSIZE> DisplayProperties<DI, DSIZE> {
     }
 }
 
-impl<DI, DSIZE> DisplayProperties<DI,DSIZE>
+impl<DI, DSIZE> DisplayProperties<DI, DSIZE>
 where
     DI: WriteOnlyDataCommand,
     DSIZE: DisplaySize,
@@ -188,8 +185,12 @@ where
     /// ```
     pub fn get_dimensions(&self) -> (u8, u8) {
         match self.display_rotation {
-            DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => (DSIZE::Width::U8, DSIZE::Height::U8),
-            DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => (DSIZE::Height::U8, DSIZE::Width::U8),
+            DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => {
+                (DSIZE::Width::U8, DSIZE::Height::U8)
+            }
+            DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => {
+                (DSIZE::Height::U8, DSIZE::Width::U8)
+            }
         }
     }
 

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -7,7 +7,6 @@ use crate::{
     displaysize::{DisplaySize, DisplaySize128x64},
 };
 use display_interface::{DataFormat::U8, DisplayError, WriteOnlyDataCommand};
-use typenum::Unsigned;
 
 /// Display properties struct
 pub struct DisplayProperties<DI, DSIZE=DisplaySize128x64> {
@@ -56,7 +55,7 @@ where
 
         Command::DisplayOn(false).send(&mut self.iface)?;
         Command::DisplayClockDiv(0x8, 0x0).send(&mut self.iface)?;
-        Command::Multiplex(DSIZE::Height::U8 - 1).send(&mut self.iface)?;
+        Command::Multiplex(DSIZE::HEIGHT - 1).send(&mut self.iface)?;
         Command::DisplayOffset(0).send(&mut self.iface)?;
         Command::StartLine(0).send(&mut self.iface)?;
         // TODO: Ability to turn charge pump on/off
@@ -65,7 +64,7 @@ where
 
         self.set_rotation(display_rotation)?;
 
-        DSIZE::ComPinConfig().send(&mut self.iface)?;
+        DSIZE::com_pin_config().send(&mut self.iface)?;
 
         self.set_brightness(Brightness::default())?;
         Command::VcomhDeselect(VcomhLevel::Auto).send(&mut self.iface)?;
@@ -186,10 +185,10 @@ where
     pub fn get_dimensions(&self) -> (u8, u8) {
         match self.display_rotation {
             DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => {
-                (DSIZE::Width::U8, DSIZE::Height::U8)
+                (DSIZE::WIDTH, DSIZE::HEIGHT)
             }
             DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => {
-                (DSIZE::Height::U8, DSIZE::Width::U8)
+                (DSIZE::HEIGHT, DSIZE::WIDTH)
             }
         }
     }

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -167,14 +167,14 @@ where
     /// # let interface = StubInterface;
     /// use ssd1306::prelude::*;
     /// #
-    /// let disp = DisplayProperties::new(
+    /// let disp: DisplayProperties<_, DisplaySize128x64> = DisplayProperties::new(
     ///     interface,
     ///     DisplayRotation::Rotate0,
     /// );
     /// assert_eq!(disp.get_dimensions(), (128, 64));
     ///
     /// # let interface = StubInterface;
-    /// let rotated_disp = DisplayProperties::new(
+    /// let rotated_disp: DisplayProperties<_, DisplaySize128x64> = DisplayProperties::new(
     ///     interface,
     ///     DisplayRotation::Rotate90,
     /// );

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -64,7 +64,7 @@ where
 
         self.set_rotation(display_rotation)?;
 
-        DSIZE::com_pin_config().send(&mut self.iface)?;
+        DSIZE::configure(&mut self.iface)?;
 
         self.set_brightness(Brightness::default())?;
         Command::VcomhDeselect(VcomhLevel::Auto).send(&mut self.iface)?;

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -1,5 +1,5 @@
 //! Container to store and set display properties
-
+use typenum::Unsigned;
 use crate::mode::displaymode::DisplayModeTrait;
 use crate::{
     brightness::Brightness,
@@ -10,47 +10,42 @@ use crate::{
 use display_interface::{DataFormat::U8, DisplayError, WriteOnlyDataCommand};
 
 /// Display properties struct
-pub struct DisplayProperties<DI> {
+pub struct DisplayProperties<DI, DSIZE> {
     iface: DI,
-    display_size: DisplaySize,
     display_rotation: DisplayRotation,
-    pub(crate) display_offset: (u8, u8),
     addr_mode: AddrMode,
+    _size: core::marker::PhantomData<DSIZE>,
 }
 
-impl<DI> DisplayProperties<DI> {
+impl<DI, DSIZE> DisplayProperties<DI, DSIZE>
+where
+    DSIZE: DisplaySize,
+{
     /// Create new DisplayProperties instance
     pub fn new(
         iface: DI,
-        display_size: DisplaySize,
         display_rotation: DisplayRotation,
-    ) -> DisplayProperties<DI> {
-        let display_offset = match display_size {
-            DisplaySize::Display128x64 => (0, 0),
-            DisplaySize::Display128x32 => (0, 0),
-            DisplaySize::Display96x16 => (0, 0),
-            DisplaySize::Display72x40 => (28, 0),
-            DisplaySize::Display64x48 => (32, 0),
-        };
-
+    ) -> DisplayProperties<DI, DSIZE> {
         DisplayProperties {
             iface,
-            display_size,
             display_rotation,
-            display_offset,
             addr_mode: AddrMode::Page, // reset value
+            _size: core::marker::PhantomData,
         }
     }
+}
 
+impl<DI, DSIZE> DisplayProperties<DI, DSIZE> {
     /// Releases the display interface
     pub fn release(self) -> DI {
         self.iface
     }
 }
 
-impl<DI> DisplayProperties<DI>
+impl<DI, DSIZE> DisplayProperties<DI,DSIZE>
 where
     DI: WriteOnlyDataCommand,
+    DSIZE: DisplaySize,
 {
     /// Initialise the display in column mode (i.e. a byte walks down a column of 8 pixels) with
     /// column 0 on the left and column _(display_width - 1)_ on the right.
@@ -60,14 +55,11 @@ where
 
     /// Initialise the display in one of the available addressing modes
     pub fn init_with_mode(&mut self, mode: AddrMode) -> Result<(), DisplayError> {
-        // TODO: Break up into nice bits so display modes can pick whathever they need
-        let (_, display_height) = self.display_size.dimensions();
-
         let display_rotation = self.display_rotation;
 
         Command::DisplayOn(false).send(&mut self.iface)?;
         Command::DisplayClockDiv(0x8, 0x0).send(&mut self.iface)?;
-        Command::Multiplex(display_height - 1).send(&mut self.iface)?;
+        Command::Multiplex(DSIZE::Height::U8 - 1).send(&mut self.iface)?;
         Command::DisplayOffset(0).send(&mut self.iface)?;
         Command::StartLine(0).send(&mut self.iface)?;
         // TODO: Ability to turn charge pump on/off
@@ -76,13 +68,7 @@ where
 
         self.set_rotation(display_rotation)?;
 
-        match self.display_size {
-            DisplaySize::Display128x32 => Command::ComPinConfig(false, false).send(&mut self.iface),
-            DisplaySize::Display128x64 => Command::ComPinConfig(true, false).send(&mut self.iface),
-            DisplaySize::Display96x16 => Command::ComPinConfig(false, false).send(&mut self.iface),
-            DisplaySize::Display72x40 => Command::ComPinConfig(true, false).send(&mut self.iface),
-            DisplaySize::Display64x48 => Command::ComPinConfig(true, false).send(&mut self.iface),
-        }?;
+        DSIZE::ComPinConfig().send(&mut self.iface)?;
 
         self.set_brightness(Brightness::default())?;
         Command::VcomhDeselect(VcomhLevel::Auto).send(&mut self.iface)?;
@@ -178,11 +164,6 @@ where
             .try_for_each(|c| self.iface.send_data(U8(&c)))
     }
 
-    /// Get the configured display size
-    pub fn get_size(&self) -> DisplaySize {
-        self.display_size
-    }
-
     /// Get display dimensions, taking into account the current rotation of the display
     ///
     /// ```rust
@@ -206,11 +187,9 @@ where
     /// assert_eq!(rotated_disp.get_dimensions(), (64, 128));
     /// ```
     pub fn get_dimensions(&self) -> (u8, u8) {
-        let (w, h) = self.display_size.dimensions();
-
         match self.display_rotation {
-            DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => (w, h),
-            DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => (h, w),
+            DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => (DSIZE::Width::U8, DSIZE::Height::U8),
+            DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => (DSIZE::Height::U8, DSIZE::Width::U8),
         }
     }
 
@@ -264,7 +243,7 @@ where
     }
 
     /// Change into any mode implementing DisplayModeTrait
-    pub fn into<NMODE: DisplayModeTrait<DI>>(self) -> NMODE
+    pub fn into<NMODE: DisplayModeTrait<DI, DSIZE>>(self) -> NMODE
     where
         DI: WriteOnlyDataCommand,
     {

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -9,7 +9,7 @@ use crate::{
 use display_interface::{DataFormat::U8, DisplayError, WriteOnlyDataCommand};
 
 /// Display properties struct
-pub struct DisplayProperties<DI, DSIZE=DisplaySize128x64> {
+pub struct DisplayProperties<DI, DSIZE = DisplaySize128x64> {
     iface: DI,
     display_rotation: DisplayRotation,
     addr_mode: AddrMode,
@@ -184,12 +184,8 @@ where
     /// ```
     pub fn get_dimensions(&self) -> (u8, u8) {
         match self.display_rotation {
-            DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => {
-                (DSIZE::WIDTH, DSIZE::HEIGHT)
-            }
-            DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => {
-                (DSIZE::HEIGHT, DSIZE::WIDTH)
-            }
+            DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => (DSIZE::WIDTH, DSIZE::HEIGHT),
+            DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => (DSIZE::HEIGHT, DSIZE::WIDTH),
         }
     }
 

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -4,13 +4,13 @@ use crate::{
     brightness::Brightness,
     command::{AddrMode, Command, VcomhLevel},
     displayrotation::DisplayRotation,
-    displaysize::DisplaySize,
+    displaysize::{DisplaySize, DisplaySize128x64},
 };
 use display_interface::{DataFormat::U8, DisplayError, WriteOnlyDataCommand};
 use typenum::Unsigned;
 
 /// Display properties struct
-pub struct DisplayProperties<DI, DSIZE> {
+pub struct DisplayProperties<DI, DSIZE=DisplaySize128x64> {
     iface: DI,
     display_rotation: DisplayRotation,
     addr_mode: AddrMode,


### PR DESCRIPTION
Hi! Thank you for helping out with SSD1306 development! Please:

- [ ] Check that you've added documentation to any new methods
- [ ] Rebase from `master` if you're not already up to date
- [ ] Add or modify an example if there are changes to the public API
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, **Changed**, etc)
- [ ] Run `rustfmt` on the project with `cargo fmt --all` - CI will not pass without this step
- [ ] Check that your branch is up to date with master and that CI is passing once the PR is opened

## PR description

This is just a rough draft of how I imagine type-level display sizes. This has several added benefits:
 - allows the user to specify display sizes
- ~can be extended via GenericArray to support flexible display buffer size~ accidentally implemented
 - hopefully allows generating much nicer machine code

The downside is the amount of code changed and the API it broke...

Closes #20 
Closes #122
