### PR TITLE
Move reset to DisplayModeTrait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 
 ### Changed
 
--**(breaking)** [#119](https://github.com/jamwaffles/ssd1306/pull/119) Remove `DisplayMode` and `RawMode`
+- **breaking** [#126](https://github.com/jamwaffles/ssd1306/pull/126) Moved `reset` method to `DisplayModeTrait`. If the prelude is not used, add either `use ssd1306::prelude::*` or `ssd1306::mode::displaymode::DisplayModeTrait` to your imports.
+- **(breaking)** [#119](https://github.com/jamwaffles/ssd1306/pull/119) Remove `DisplayMode` and `RawMode`
 - [#120](https://github.com/jamwaffles/ssd1306/pull/120) Update to v0.4 [`display-interface`](https://crates.io/crates/display-interface)
 - **(breaking)** [#118](https://github.com/jamwaffles/ssd1306/pull/118) Change `release` method to return the display interface instead of the `DisplayProperties`.
 - **(breaking)** [#116](https://github.com/jamwaffles/ssd1306/pull/116) Replace custom I2C and SPI interfaces by generic [`display-interface`](https://crates.io/crates/display-interface)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Changed
 
-- **breaking** [#126](https://github.com/jamwaffles/ssd1306/pull/126) Moved `reset` method to `DisplayModeTrait`. If the prelude is not used, add either `use ssd1306::prelude::*` or `ssd1306::mode::displaymode::DisplayModeTrait` to your imports.
+- **(breaking)** [#126](https://github.com/jamwaffles/ssd1306/pull/126) Moved `reset` method to `DisplayModeTrait`. If the prelude is not used, add either `use ssd1306::prelude::*` or `ssd1306::mode::displaymode::DisplayModeTrait` to your imports.
 - **(breaking)** [#119](https://github.com/jamwaffles/ssd1306/pull/119) Remove `DisplayMode` and `RawMode`
 - [#120](https://github.com/jamwaffles/ssd1306/pull/120) Update to v0.4 [`display-interface`](https://crates.io/crates/display-interface)
 - **(breaking)** [#118](https://github.com/jamwaffles/ssd1306/pull/118) Change `release` method to return the display interface instead of the `DisplayProperties`.

--- a/src/mode/displaymode.rs
+++ b/src/mode/displaymode.rs
@@ -1,6 +1,8 @@
 //! Abstraction of different operating modes for the SSD1306
 
 use crate::properties::DisplayProperties;
+use crate::Error;
+use hal::{blocking::delay::DelayMs, digital::v2::OutputPin};
 
 /// Trait with core functionality for display mode switching
 pub trait DisplayModeTrait<DI>: Sized {
@@ -13,5 +15,22 @@ pub trait DisplayModeTrait<DI>: Sized {
     /// Release display interface
     fn release(self) -> DI {
         self.into_properties().release()
+    }
+
+    /// Reset the display
+    fn reset<RST, DELAY, PinE>(
+        &mut self,
+        rst: &mut RST,
+        delay: &mut DELAY,
+    ) -> Result<(), Error<(), PinE>>
+    where
+        RST: OutputPin<Error = PinE>,
+        DELAY: DelayMs<u8>,
+    {
+        rst.set_high().map_err(Error::Pin)?;
+        delay.delay_ms(1);
+        rst.set_low().map_err(Error::Pin)?;
+        delay.delay_ms(10);
+        rst.set_high().map_err(Error::Pin)
     }
 }

--- a/src/mode/graphics.rs
+++ b/src/mode/graphics.rs
@@ -56,11 +56,10 @@
 //! [embedded_graphics]: https://crates.io/crates/embedded_graphics
 
 use display_interface::{DisplayError, WriteOnlyDataCommand};
-use hal::{blocking::delay::DelayMs, digital::v2::OutputPin};
 
 use crate::{
     displayrotation::DisplayRotation, mode::displaymode::DisplayModeTrait,
-    properties::DisplayProperties, Error,
+    properties::DisplayProperties,
 };
 
 // TODO: Add to prelude
@@ -90,26 +89,6 @@ impl<DI> DisplayModeTrait<DI> for GraphicsMode<DI> {
     /// Release display interface used by `GraphicsMode`
     fn into_properties(self) -> DisplayProperties<DI> {
         self.properties
-    }
-}
-
-impl<DI> GraphicsMode<DI> {
-    /// Reset display
-    // TODO: Move to a more appropriate place
-    pub fn reset<RST, DELAY, PinE>(
-        &mut self,
-        rst: &mut RST,
-        delay: &mut DELAY,
-    ) -> Result<(), Error<(), PinE>>
-    where
-        RST: OutputPin<Error = PinE>,
-        DELAY: DelayMs<u8>,
-    {
-        rst.set_high().map_err(Error::Pin)?;
-        delay.delay_ms(1);
-        rst.set_low().map_err(Error::Pin)?;
-        delay.delay_ms(10);
-        rst.set_high().map_err(Error::Pin)
     }
 }
 

--- a/src/mode/terminal.rs
+++ b/src/mode/terminal.rs
@@ -36,10 +36,8 @@ use crate::{
         terminal::TerminalModeError::{InterfaceError, OutOfBounds, Uninitialized},
     },
     properties::DisplayProperties,
-    Error,
 };
 use core::{cmp::min, fmt};
-use hal::{blocking::delay::DelayMs, digital::v2::OutputPin};
 
 /// Contains the new row that the cursor has wrapped around to
 struct CursorWrapEvent(u8);
@@ -156,25 +154,6 @@ where
     /// Release display interface used by `TerminalMode`
     fn into_properties(self) -> DisplayProperties<DI> {
         self.properties
-    }
-}
-
-impl<DI> TerminalMode<DI> {
-    /// Reset display
-    pub fn reset<RST, DELAY, PinE>(
-        &mut self,
-        rst: &mut RST,
-        delay: &mut DELAY,
-    ) -> Result<(), Error<(), PinE>>
-    where
-        RST: OutputPin<Error = PinE>,
-        DELAY: DelayMs<u8>,
-    {
-        rst.set_high().map_err(Error::Pin)?;
-        delay.delay_ms(1);
-        rst.set_low().map_err(Error::Pin)?;
-        delay.delay_ms(10);
-        rst.set_high().map_err(Error::Pin)
     }
 }
 


### PR DESCRIPTION
The functionality is common, so the implementation can be as well.

Hi! Thank you for helping out with SSD1306 development! Please:

- [ ] Check that you've added documentation to any new methods
- [ ] Rebase from `master` if you're not already up to date
- [ ] Add or modify an example if there are changes to the public API
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, **Changed**, etc)
- [ ] Run `rustfmt` on the project with `cargo fmt --all` - CI will not pass without this step
- [ ] Check that your branch is up to date with master and that CI is passing once the PR is opened

## PR description

Just a bit of cleanup. Should be backwards compatible since the trait is in the prelude. I don't think there should be a changelog entry for this one.
