### PR TITLE
Fix terminal mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Changed
 
+- **(breaking)** [#129](https://github.com/jamwaffles/ssd1306/pull/129) `TerminalMode::set_rotation` now resets the cursor position
 - **(breaking)** [#125](https://github.com/jamwaffles/ssd1306/pull/125) Redesigned display size handling.
 - **(breaking)** [#126](https://github.com/jamwaffles/ssd1306/pull/126) Moved `reset` method to `DisplayModeTrait`. If the prelude is not used, add either `use ssd1306::prelude::*` or `ssd1306::mode::displaymode::DisplayModeTrait` to your imports.
 - **(breaking)** [#119](https://github.com/jamwaffles/ssd1306/pull/119) Remove `DisplayMode` and `RawMode`
@@ -20,6 +21,10 @@
 - **(breaking)** [#118](https://github.com/jamwaffles/ssd1306/pull/118) Change `release` method to return the display interface instead of the `DisplayProperties`.
 - **(breaking)** [#116](https://github.com/jamwaffles/ssd1306/pull/116) Replace custom I2C and SPI interfaces by generic [`display-interface`](https://crates.io/crates/display-interface)
 - **(breaking)** [#113](https://github.com/jamwaffles/ssd1306/pull/113) Removed public `send_bounded_data` from DisplayInterface and implementations
+
+### Fixed
+
+- [#129](https://github.com/jamwaffles/ssd1306/pull/129) Fixed `Rotate90` and `Rotate270` rotation modes for `TerminalMode`
 
 ## [0.3.1] - 2020-03-21
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -113,9 +113,7 @@ where
         }
     }
 
-    /// Set the rotation of the display to one of four values. Defaults to no rotation. Note that
-    /// 90º and 270º rotations are not supported by
-    /// [`TerminalMode`](../mode/terminal/struct.TerminalMode.html).
+    /// Set the rotation of the display to one of four values. Defaults to no rotation.
     pub fn with_rotation(self, rotation: DisplayRotation) -> Self {
         Self { rotation, ..self }
     }

--- a/src/displayrotation.rs
+++ b/src/displayrotation.rs
@@ -2,9 +2,6 @@
 
 // TODO: Add to prelude
 /// Display rotation.
-///
-/// Note that 90º and 270º rotations are not supported by
-// [`TerminalMode`](../mode/terminal/struct.TerminalMode.html).
 #[derive(Clone, Copy)]
 pub enum DisplayRotation {
     /// No rotation, normal display

--- a/src/displayrotation.rs
+++ b/src/displayrotation.rs
@@ -1,6 +1,5 @@
 //! Display rotation
 
-// TODO: Add to prelude
 /// Display rotation.
 #[derive(Clone, Copy)]
 pub enum DisplayRotation {

--- a/src/mode/terminal.rs
+++ b/src/mode/terminal.rs
@@ -310,14 +310,15 @@ where
         if column >= width || row >= height {
             Err(OutOfBounds)
         } else {
+            let (display_x_offset, display_y_offset) = self.properties.display_offset;
             match self.properties.get_rotation() {
                 DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => {
-                    self.properties.set_column(column * 8).terminal_err()?;
-                    self.properties.set_row(row * 8).terminal_err()?;
+                    self.properties.set_column(display_x_offset + column * 8).terminal_err()?;
+                    self.properties.set_row(display_y_offset + row * 8).terminal_err()?;
                 }
                 DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => {
-                    self.properties.set_column(row * 8).terminal_err()?;
-                    self.properties.set_row(column * 8).terminal_err()?;
+                    self.properties.set_column(display_x_offset + row * 8).terminal_err()?;
+                    self.properties.set_row(display_y_offset + column * 8).terminal_err()?;
                 }
             }
             self.ensure_cursor()?.set_position(column, row);
@@ -327,10 +328,11 @@ where
 
     /// Reset the draw area and move pointer to the top left corner
     fn reset_pos(&mut self) -> Result<(), TerminalModeError> {
-        self.properties.set_column(DSIZE::OFFSETX).terminal_err()?;
-        self.properties.set_row(DSIZE::OFFSETY).terminal_err()?;
         // Initialise the counter when we know it's valid
         self.cursor = Some(Cursor::new(DSIZE::WIDTH, DSIZE::HEIGHT));
+
+        // Reset cursor position
+        self.set_position(0, 0)?;
 
         Ok(())
     }

--- a/src/mode/terminal.rs
+++ b/src/mode/terminal.rs
@@ -253,9 +253,7 @@ where
                     }
                 };
 
-                self.properties
-                    .draw(&bitmap)
-                    .terminal_err()?;
+                self.properties.draw(&bitmap).terminal_err()?;
 
                 // Increment character counter and potentially wrap line
                 self.advance_cursor()?;

--- a/src/mode/terminal.rs
+++ b/src/mode/terminal.rs
@@ -3,7 +3,6 @@
 //! This mode uses the 7x7 pixel [MarioChrome](https://github.com/techninja/MarioChron/) font to
 //! draw characters to the display without needing a framebuffer. It will write characters from top
 //! left to bottom right in an 8x8 pixel grid, restarting at the top left of the display once full.
-//! The display itself takes care of wrapping lines.
 //!
 //! ```rust
 //! # use ssd1306::test_helpers::I2cStub;

--- a/src/mode/terminal.rs
+++ b/src/mode/terminal.rs
@@ -274,9 +274,12 @@ where
     }
 
     /// Set the display rotation
+    ///
+    /// This method resets the cursor but does not clear the screen.
     pub fn set_rotation(&mut self, rot: DisplayRotation) -> Result<(), TerminalModeError> {
-        // we don't need to touch the cursor because rotating 90º or 270º currently just flips
-        self.properties.set_rotation(rot).terminal_err()
+        self.properties.set_rotation(rot).terminal_err()?;
+        // Need to reset cursor position, otherwise coordinates can become invalid
+        self.reset_pos()
     }
 
     /// Turn the display on or off. The display can be drawn to and retains all

--- a/src/mode/terminal.rs
+++ b/src/mode/terminal.rs
@@ -313,12 +313,20 @@ where
             let (display_x_offset, display_y_offset) = self.properties.display_offset;
             match self.properties.get_rotation() {
                 DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => {
-                    self.properties.set_column(display_x_offset + column * 8).terminal_err()?;
-                    self.properties.set_row(display_y_offset + row * 8).terminal_err()?;
+                    self.properties
+                        .set_column(display_x_offset + column * 8)
+                        .terminal_err()?;
+                    self.properties
+                        .set_row(display_y_offset + row * 8)
+                        .terminal_err()?;
                 }
                 DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => {
-                    self.properties.set_column(display_x_offset + row * 8).terminal_err()?;
-                    self.properties.set_row(display_y_offset + column * 8).terminal_err()?;
+                    self.properties
+                        .set_column(display_x_offset + row * 8)
+                        .terminal_err()?;
+                    self.properties
+                        .set_row(display_y_offset + column * 8)
+                        .terminal_err()?;
                 }
             }
             self.ensure_cursor()?.set_position(column, row);

--- a/src/mode/terminal.rs
+++ b/src/mode/terminal.rs
@@ -200,6 +200,8 @@ where
         self.properties
             .change_mode(AddrMode::Horizontal)
             .terminal_err()?;
+        let (display_width, display_height) = display_size.dimensions();
+        let (display_x_offset, display_y_offset) = self.properties.display_offset;
         self.properties
             .set_draw_area(
                 (DSIZE::OFFSETX, DSIZE::OFFSETY),

--- a/src/mode/terminal.rs
+++ b/src/mode/terminal.rs
@@ -199,8 +199,6 @@ where
         self.properties
             .change_mode(AddrMode::Horizontal)
             .terminal_err()?;
-        let (display_width, display_height) = display_size.dimensions();
-        let (display_x_offset, display_y_offset) = self.properties.display_offset;
         self.properties
             .set_draw_area(
                 (DSIZE::OFFSETX, DSIZE::OFFSETY),
@@ -310,22 +308,21 @@ where
         if column >= width || row >= height {
             Err(OutOfBounds)
         } else {
-            let (display_x_offset, display_y_offset) = self.properties.display_offset;
             match self.properties.get_rotation() {
                 DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => {
                     self.properties
-                        .set_column(display_x_offset + column * 8)
+                        .set_column(DSIZE::OFFSETX + column * 8)
                         .terminal_err()?;
                     self.properties
-                        .set_row(display_y_offset + row * 8)
+                        .set_row(DSIZE::OFFSETY + row * 8)
                         .terminal_err()?;
                 }
                 DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => {
                     self.properties
-                        .set_column(display_x_offset + row * 8)
+                        .set_column(DSIZE::OFFSETX + row * 8)
                         .terminal_err()?;
                     self.properties
-                        .set_row(display_y_offset + column * 8)
+                        .set_row(DSIZE::OFFSETY + column * 8)
                         .terminal_err()?;
                 }
             }


### PR DESCRIPTION
Hi! Thank you for helping out with SSD1306 development! Please:

- [x] Check that you've added documentation to any new methods
- [x] Rebase from `master` if you're not already up to date
- [x] Add or modify an example if there are changes to the public API
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, **Changed**, etc)
- [x] Run `rustfmt` on the project with `cargo fmt --all` - CI will not pass without this step
- [x] Check that your branch is up to date with master and that CI is passing once the PR is opened

## PR description

~I had a go with #85 and failed miserably. But while doing so, I discovered the driver crashes with 90° rotation. This PR fixes that crash, but does nothing to fix the rotation issue.~

The issue is, properties.get_dimension flips width and height but set_draw_area expects them in the original order. I think for clearing it doesn't matter which direction we go, so I'm using the original physical size instead.

This is a performance hit, because every cursor move sends several display commands, but all the rotation values are rendered correctly.