### PR TITLE
Exclude various files from the cargo package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ repository = "https://github.com/jamwaffles/ssd1306"
 version = "0.5.0"
 edition = "2018"
 
+exclude = [ "build.rs", "build.sh", "memory.x", "doc", "*.jpg", "*.png", "*.bmp" ]
+
 [badges]
 circle-ci = { repository = "jamwaffles/ssd1306", branch = "master" }
 


### PR DESCRIPTION
Remove `memory.x`, `build.rs` and various binary files from the published crate. A side effect is that size of the bundle is decreased down to 35 KB from 2.4 MB.

Closes #143 