### PR TITLE
Fix display rotation for different screen sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## [Unreleased] - ReleaseDate
 
+- [#145](https://github.com/jamwaffles/ssd1306/pull/145) Fixed rotation for 96x16 and 72x40 displays.
+
 ## [0.5.1] - 2021-01-09
 
 ## [0.5.0] - 2020-12-21

--- a/src/displaysize.rs
+++ b/src/displaysize.rs
@@ -18,6 +18,12 @@ pub trait DisplaySize {
     /// Height in pixels
     const HEIGHT: u8;
 
+    /// Maximum width supported by the display driver
+    const DRIVER_COLS: u8 = 128;
+
+    /// Maximum height supported by the display driver
+    const DRIVER_ROWS: u8 = 64;
+
     /// Horizontal offset in pixels
     const OFFSETX: u8 = 0;
 

--- a/src/mode/graphics.rs
+++ b/src/mode/graphics.rs
@@ -146,13 +146,20 @@ where
         self.max_y = 0;
 
         // Tell the display to update only the part that has changed
+        let offset_x = match self.properties.get_rotation() {
+            DisplayRotation::Rotate0 | DisplayRotation::Rotate270 => DSIZE::OFFSETX,
+            DisplayRotation::Rotate180 | DisplayRotation::Rotate90 => {
+                // If segment remapping is flipped, we need to calculate
+                // the offset from the other edge of the display.
+                DSIZE::DRIVER_COLS - DSIZE::WIDTH - DSIZE::OFFSETX
+            }
+        };
         match self.properties.get_rotation() {
             DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => {
                 self.properties.set_draw_area(
-                    (disp_min_x + DSIZE::OFFSETX, disp_min_y + DSIZE::OFFSETY),
-                    (disp_max_x + DSIZE::OFFSETX, disp_max_y + DSIZE::OFFSETY),
+                    (disp_min_x + offset_x, disp_min_y + DSIZE::OFFSETY),
+                    (disp_max_x + offset_x, disp_max_y + DSIZE::OFFSETY),
                 )?;
-
                 self.properties.bounded_draw(
                     &self.buffer,
                     width as usize,
@@ -162,10 +169,9 @@ where
             }
             DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => {
                 self.properties.set_draw_area(
-                    (disp_min_y + DSIZE::OFFSETY, disp_min_x + DSIZE::OFFSETX),
-                    (disp_max_y + DSIZE::OFFSETY, disp_max_x + DSIZE::OFFSETX),
+                    (disp_min_y + offset_x, disp_min_x + DSIZE::OFFSETY),
+                    (disp_max_y + offset_x, disp_max_x + DSIZE::OFFSETY),
                 )?;
-
                 self.properties.bounded_draw(
                     &self.buffer,
                     height as usize,


### PR DESCRIPTION
Hi! Thank you for helping out with SSD1306 development! Please:

- [ ] Check that you've added documentation to any new methods
- [ ] Rebase from `master` if you're not already up to date
- [ ] Add or modify an example if there are changes to the public API
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, **Changed**, etc)
- [ ] Run `rustfmt` on the project with `cargo fmt --all` - CI will not pass without this step
- [ ] Check that your branch is up to date with master and that CI is passing once the PR is opened

## PR description

All display sizes, except for the 96x16 are centered, meaning OFFSETX is same for both 0 and 180 rotations. The 96x16 is an exception to this, where it's OFFSETX is 0.

This PR changes `flush()` so it doesn't assume a symmetrical display. I also added the option to specify different driver sizes, but I'm pretty sure the only reason for that in this driver is to avoid a magic number (128) in the code.

Also 72x40 rotation was broken due to swapped X/Y offsets.

Tested on 128x32, 72x40 and 96x16 displays.

Closes #138