### PR TITLE
Use embedded-graphics-core instead of embedded-graphics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Changed
 
-- **(breaking)** [#154](https://github.com/jamwaffles/ssd1306/pull/154) Upgrade to `embedded-graphics` 0.7.
+- **(breaking)** [#156](https://github.com/jamwaffles/ssd1306/pull/156) Migrate from `embedded-graphics` to `embedded-graphics-core`.
 - **(breaking)** [#150](https://github.com/jamwaffles/ssd1306/pull/150) `BufferedGraphicsMode::set_pixel` now accepts a `bool` instead of a `u8` for the pixel color value.
 - **(breaking)** [#150](https://github.com/jamwaffles/ssd1306/pull/150) `display_on` is now called `set_display_on`.
 - **(breaking)** [#150](https://github.com/jamwaffles/ssd1306/pull/150) `TerminalMode::get_position` is now called `position` to conform with Rust API guidelines.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,35 +19,25 @@ circle-ci = { repository = "jamwaffles/ssd1306", branch = "master" }
 targets = [ "thumbv7m-none-eabi", "thumbv7em-none-eabihf" ]
 
 [dependencies]
-embedded-hal = "0.2.3"
-display-interface = "0.4"
-display-interface-i2c = "0.4"
-display-interface-spi = "0.4"
-generic-array = "0.14.2"
-
-[dependencies.embedded-graphics-core]
-optional = true
-version = "0.3.2"
+embedded-hal = "0.2.5"
+display-interface = "0.4.1"
+display-interface-i2c = "0.4.0"
+display-interface-spi = "0.4.1"
+generic-array = "0.14.4"
+embedded-graphics-core = { version = "0.3.2", optional = true }
 
 [dev-dependencies]
 cortex-m = "0.7.2"
-cortex-m-rt = "0.6.12"
-cortex-m-rtic = "0.5.3"
+cortex-m-rt = "0.6.14"
+cortex-m-rtic = "0.5.6"
 panic-halt = "0.2.0"
 cast = { version = "0.2.6", default-features = false }
 # Used to load BMP images in various examples
-tinybmp = "0.3.0"
+tinybmp = "0.3.1"
 embedded-graphics = "0.7.1"
-
 # Used by the noise_i2c examples
-[dev-dependencies.rand]
-version = "0.8.3"
-default-features = false
-features = [ "small_rng" ]
-
-[dev-dependencies.stm32f1xx-hal]
-version = "0.7.0"
-features = [ "rt", "stm32f103" ]
+rand = { version = "0.8.4", default-features = false, features = [ "small_rng" ] }
+stm32f1xx-hal = { version = "0.7.0", features = [ "rt", "stm32f103" ] }
 
 [features]
 default = ["graphics"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,9 @@ display-interface-i2c = "0.4"
 display-interface-spi = "0.4"
 generic-array = "0.14.2"
 
-[dependencies.embedded-graphics]
+[dependencies.embedded-graphics-core]
 optional = true
-version = "0.7.0"
+version = "0.3.2"
 
 [dev-dependencies]
 cortex-m = "0.7.2"
@@ -37,6 +37,7 @@ panic-halt = "0.2.0"
 cast = { version = "0.2.6", default-features = false }
 # Used to load BMP images in various examples
 tinybmp = "0.3.0"
+embedded-graphics = "0.7.1"
 
 # Used by the noise_i2c examples
 [dev-dependencies.rand]
@@ -50,7 +51,7 @@ features = [ "rt", "stm32f103" ]
 
 [features]
 default = ["graphics"]
-graphics = ["embedded-graphics"]
+graphics = ["embedded-graphics-core"]
 
 [profile.dev]
 codegen-units = 1

--- a/src/mode/buffered_graphics.rs
+++ b/src/mode/buffered_graphics.rs
@@ -2,7 +2,6 @@
 
 use crate::{command::AddrMode, rotation::DisplayRotation, size::DisplaySize, Ssd1306};
 use display_interface::{DisplayError, WriteOnlyDataCommand};
-use embedded_graphics::prelude::Dimensions;
 use generic_array::GenericArray;
 
 /// Buffered graphics mode.
@@ -186,8 +185,11 @@ where
 }
 
 #[cfg(feature = "graphics")]
-use embedded_graphics::{
-    draw_target::DrawTarget, geometry::OriginDimensions, geometry::Size, pixelcolor::BinaryColor,
+use embedded_graphics_core::{
+    draw_target::DrawTarget,
+    geometry::Size,
+    geometry::{Dimensions, OriginDimensions},
+    pixelcolor::BinaryColor,
     Pixel,
 };
 


### PR DESCRIPTION
Hi! Thank you for helping out with SSD1306 development! Please:

- [x] Check that you've added documentation to any new methods
- [x] Rebase from `master` if you're not already up to date
- [x] Add or modify an example if there are changes to the public API
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, **Changed**, etc)
- [x] Run `rustfmt` on the project with `cargo fmt --all` - CI will not pass without this step
- [x] Check that your branch is up to date with master and that CI is passing once the PR is opened

## PR description

The new core crate is designed for driver use, hence this PR. Also some minor cleanup in `Cargo.toml`.
