### PR TITLE
Get rid of generic-array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- **(breaking)** [#158](https://github.com/jamwaffles/ssd1306/pull/158) Migrate away from `generic-array` to a solution using const generics.
+
 ## [0.6.0] - 2021-06-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Changed
 
-- **(breaking)** [#158](https://github.com/jamwaffles/ssd1306/pull/158) Migrate away from `generic-array` to a solution using const generics.
+- **(breaking)** [#158](https://github.com/jamwaffles/ssd1306/pull/158) Migrate away from `generic-array` to a solution using const generics. This raises the crate MSRV to 1.51.
 
 ## [0.6.0] - 2021-06-22
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ embedded-hal = "0.2.5"
 display-interface = "0.4.1"
 display-interface-i2c = "0.4.0"
 display-interface-spi = "0.4.1"
-generic-array = "0.14.4"
 embedded-graphics-core = { version = "0.3.2", optional = true }
 
 [dev-dependencies]

--- a/src/size.rs
+++ b/src/size.rs
@@ -2,10 +2,18 @@
 
 use super::command::Command;
 use display_interface::{DisplayError, WriteOnlyDataCommand};
-use generic_array::{
-    typenum::{U1024, U192, U360, U384, U512},
-    ArrayLength,
-};
+
+/// Workaround trait, since `Default` is only implemented to arrays up to 32 of size
+pub trait NewZeroed {
+    /// Creates a new value with its memory set to zero
+    fn new_zeroed() -> Self;
+}
+
+impl<const N: usize> NewZeroed for [u8; N] {
+    fn new_zeroed() -> Self {
+        [0u8; N]
+    }
+}
 
 /// Display information.
 ///
@@ -32,7 +40,7 @@ pub trait DisplaySize {
 
     /// Size of framebuffer. Because the display is monocrome, this is
     /// width * height / 8
-    type BufferSize: ArrayLength<u8>;
+    type Buffer: AsMut<[u8]> + NewZeroed;
 
     /// Send resolution and model-dependent configuration to the display
     ///
@@ -48,7 +56,7 @@ pub struct DisplaySize128x64;
 impl DisplaySize for DisplaySize128x64 {
     const WIDTH: u8 = 128;
     const HEIGHT: u8 = 64;
-    type BufferSize = U1024;
+    type Buffer = [u8; 1024];
 
     fn configure(&self, iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
         Command::ComPinConfig(true, false).send(iface)
@@ -61,7 +69,7 @@ pub struct DisplaySize128x32;
 impl DisplaySize for DisplaySize128x32 {
     const WIDTH: u8 = 128;
     const HEIGHT: u8 = 32;
-    type BufferSize = U512;
+    type Buffer = [u8; 512];
 
     fn configure(&self, iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
         Command::ComPinConfig(false, false).send(iface)
@@ -74,7 +82,7 @@ pub struct DisplaySize96x16;
 impl DisplaySize for DisplaySize96x16 {
     const WIDTH: u8 = 96;
     const HEIGHT: u8 = 16;
-    type BufferSize = U192;
+    type Buffer = [u8; 192];
 
     fn configure(&self, iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
         Command::ComPinConfig(false, false).send(iface)
@@ -89,7 +97,7 @@ impl DisplaySize for DisplaySize72x40 {
     const HEIGHT: u8 = 40;
     const OFFSETX: u8 = 28;
     const OFFSETY: u8 = 0;
-    type BufferSize = U360;
+    type Buffer = [u8; 360];
 
     fn configure(&self, iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
         Command::ComPinConfig(true, false).send(iface)?;
@@ -105,7 +113,7 @@ impl DisplaySize for DisplaySize64x48 {
     const HEIGHT: u8 = 48;
     const OFFSETX: u8 = 32;
     const OFFSETY: u8 = 0;
-    type BufferSize = U384;
+    type Buffer = [u8; 384];
 
     fn configure(&self, iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
         Command::ComPinConfig(true, false).send(iface)

--- a/src/size.rs
+++ b/src/size.rs
@@ -56,7 +56,7 @@ pub struct DisplaySize128x64;
 impl DisplaySize for DisplaySize128x64 {
     const WIDTH: u8 = 128;
     const HEIGHT: u8 = 64;
-    type Buffer = [u8; 1024];
+    type Buffer = [u8; Self::WIDTH as usize * Self::HEIGHT as usize / 8];
 
     fn configure(&self, iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
         Command::ComPinConfig(true, false).send(iface)
@@ -69,7 +69,7 @@ pub struct DisplaySize128x32;
 impl DisplaySize for DisplaySize128x32 {
     const WIDTH: u8 = 128;
     const HEIGHT: u8 = 32;
-    type Buffer = [u8; 512];
+    type Buffer = [u8; Self::WIDTH as usize * Self::HEIGHT as usize / 8];
 
     fn configure(&self, iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
         Command::ComPinConfig(false, false).send(iface)
@@ -82,7 +82,7 @@ pub struct DisplaySize96x16;
 impl DisplaySize for DisplaySize96x16 {
     const WIDTH: u8 = 96;
     const HEIGHT: u8 = 16;
-    type Buffer = [u8; 192];
+    type Buffer = [u8; Self::WIDTH as usize * Self::HEIGHT as usize / 8];
 
     fn configure(&self, iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
         Command::ComPinConfig(false, false).send(iface)
@@ -97,7 +97,7 @@ impl DisplaySize for DisplaySize72x40 {
     const HEIGHT: u8 = 40;
     const OFFSETX: u8 = 28;
     const OFFSETY: u8 = 0;
-    type Buffer = [u8; 360];
+    type Buffer = [u8; Self::WIDTH as usize * Self::HEIGHT as usize / 8];
 
     fn configure(&self, iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
         Command::ComPinConfig(true, false).send(iface)?;
@@ -113,7 +113,7 @@ impl DisplaySize for DisplaySize64x48 {
     const HEIGHT: u8 = 48;
     const OFFSETX: u8 = 32;
     const OFFSETY: u8 = 0;
-    type Buffer = [u8; 384];
+    type Buffer = [u8; Self::WIDTH as usize * Self::HEIGHT as usize / 8];
 
     fn configure(&self, iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
         Command::ComPinConfig(true, false).send(iface)


### PR DESCRIPTION
Hi! Thank you for helping out with SSD1306 development! Please:

- [x] Check that you've added documentation to any new methods
- [x] Rebase from `master` if you're not already up to date
- [ ] Add or modify an example if there are changes to the public API
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, **Changed**, etc)
- [x] Run `rustfmt` on the project with `cargo fmt --all` - CI will not pass without this step
- [x] Check that your branch is up to date with master and that CI is passing once the PR is opened

## PR description

`generic-array` really inhibits compiler optimizations, especially when creating one. And since we have big buffers using `GenericArray`, it does make a really big difference. I was having trouble with stack overflows on my 4kB RAM chip, so I went to measure RAM usage, `do_thing` is a function that creates a display driver and prints an simple image to the display:

Current release:
```
0x08000d59      4208    f0_embassy::do_thing::h6248afff2c8c745f
```

With this PR:
```
0x08000d59      1192    f0_embassy::do_thing::h8f7d94a24b293d88
```
