### PR TITLE
Add DisplaySize configuration for 64x32 displays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Added
 
 - [#161](https://github.com/jamwaffles/ssd1306/pull/161) Added a `set_mirror` method to enable or disable display mirroring.
+- [#166](https://github.com/jamwaffles/ssd1306/pull/166) Added `DisplaySize` configuration for 64x32 displays
 
 ## [0.7.0] - 2021-07-08
 

--- a/src/size.rs
+++ b/src/size.rs
@@ -119,3 +119,18 @@ impl DisplaySize for DisplaySize64x48 {
         Command::ComPinConfig(true, false).send(iface)
     }
 }
+
+/// Size information for the common 64x32 variants
+#[derive(Debug, Copy, Clone)]
+pub struct DisplaySize64x32;
+impl DisplaySize for DisplaySize64x32 {
+    const WIDTH: u8 = 64;
+    const HEIGHT: u8 = 32;
+    const OFFSETX: u8 = 32;
+    const OFFSETY: u8 = 0;
+    type Buffer = [u8; Self::WIDTH as usize * Self::HEIGHT as usize / 8];
+
+    fn configure(&self, iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
+        Command::ComPinConfig(true, false).send(iface)
+    }
+}


### PR DESCRIPTION
- [x] Check that you've added documentation to any new methods
- [x] Rebase from `master` if you're not already up to date
- [x] Add or modify an example if there are changes to the public API
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, **Changed**, etc)
- [x] Run `rustfmt` on the project with `cargo fmt --all` - CI will not pass without this step
- [x] Check that your branch is up to date with master and that CI is passing once the PR is opened

## PR description

Adding a predefined configuration for 64x32 displays, commonly marketed as "0.49" OLED display" like [this panel](https://www.buydisplay.com/0-49-inch-oled-display-module-64x32-pixel-ssd1306-spi-i2c-white-on-black) or [this module](https://www.buydisplay.com/i2c-white-0-49-inch-oled-display-module-64x32-arduino-raspberry-pi).