### PR TITLE
Remove a generic param, signify no comm error during reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Changed
 
 - **(breaking)** [#175](https://github.com/jamwaffles/ssd1306/pull/175) Increased MSRV to 1.57.0
+- **(breaking)** [#179](https://github.com/jamwaffles/ssd1306/pull/179) Changed `Ssd1306::reset` signature.
 
 ## [0.7.1] - 2022-08-15
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,8 @@ pub mod size;
 #[doc(hidden)]
 pub mod test_helpers;
 
+use core::convert::Infallible;
+
 pub use crate::i2c_interface::I2CDisplayInterface;
 use crate::mode::BasicMode;
 use brightness::Brightness;
@@ -412,43 +414,43 @@ where
 // SPI-only reset
 impl<SPI, DC, SIZE, MODE> Ssd1306<SPIInterfaceNoCS<SPI, DC>, SIZE, MODE> {
     /// Reset the display.
-    pub fn reset<RST, DELAY, PinE>(
+    pub fn reset<RST, DELAY>(
         &mut self,
         rst: &mut RST,
         delay: &mut DELAY,
-    ) -> Result<(), Error<(), PinE>>
+    ) -> Result<(), Error<Infallible, RST::Error>>
     where
-        RST: OutputPin<Error = PinE>,
+        RST: OutputPin,
         DELAY: DelayMs<u8>,
     {
-        inner_reset(rst, delay)
+        inner_reset(rst, delay).map_err(Error::Pin)
     }
 }
 
 // SPI-only reset
 impl<SPI, DC, CS, SIZE, MODE> Ssd1306<SPIInterface<SPI, DC, CS>, SIZE, MODE> {
     /// Reset the display.
-    pub fn reset<RST, DELAY, PinE>(
+    pub fn reset<RST, DELAY>(
         &mut self,
         rst: &mut RST,
         delay: &mut DELAY,
-    ) -> Result<(), Error<(), PinE>>
+    ) -> Result<(), Error<Infallible, RST::Error>>
     where
-        RST: OutputPin<Error = PinE>,
+        RST: OutputPin,
         DELAY: DelayMs<u8>,
     {
-        inner_reset(rst, delay)
+        inner_reset(rst, delay).map_err(Error::Pin)
     }
 }
 
-fn inner_reset<RST, DELAY, PinE>(rst: &mut RST, delay: &mut DELAY) -> Result<(), Error<(), PinE>>
+fn inner_reset<RST, DELAY>(rst: &mut RST, delay: &mut DELAY) -> Result<(), RST::Error>
 where
-    RST: OutputPin<Error = PinE>,
+    RST: OutputPin,
     DELAY: DelayMs<u8>,
 {
-    rst.set_high().map_err(Error::Pin)?;
+    rst.set_high()?;
     delay.delay_ms(1);
-    rst.set_low().map_err(Error::Pin)?;
+    rst.set_low()?;
     delay.delay_ms(10);
-    rst.set_high().map_err(Error::Pin)
+    rst.set_high()
 }


### PR DESCRIPTION
Hi! Thank you for helping out with SSD1306 development! Please:

- [x] Check that you've added documentation to any new methods
- [x] Rebase from `master` if you're not already up to date
- [x] Add or modify an example if there are changes to the public API
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, **Changed**, etc)
- [x] Run `rustfmt` on the project with `cargo fmt --all` - CI will not pass without this step
- [x] Check that your branch is up to date with master and that CI is passing once the PR is opened

## PR description

Reset can't return a comm error, so let's make it Infallible. Also, there's no need for a third generic type.