### PR TITLE
Move interface-independent code out into new impl blocks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,6 @@ pub struct Ssd1306<DI, SIZE, MODE> {
 
 impl<DI, SIZE> Ssd1306<DI, SIZE, BasicMode>
 where
-    DI: WriteOnlyDataCommand,
     SIZE: DisplaySize,
 {
     /// Create a basic SSD1306 interface.
@@ -165,7 +164,6 @@ where
 
 impl<DI, SIZE, MODE> Ssd1306<DI, SIZE, MODE>
 where
-    DI: WriteOnlyDataCommand,
     SIZE: DisplaySize,
 {
     /// Convert the display into another interface mode.
@@ -194,65 +192,102 @@ where
         self.into_mode(TerminalMode::new())
     }
 
-    /// Initialise the display in one of the available addressing modes.
-    pub fn init_with_addr_mode(&mut self, mode: AddrMode) -> Result<(), DisplayError> {
-        let rotation = self.rotation;
+    fn rotation_commands(&self, rotation: DisplayRotation) -> [Command; 2] {
+        let (remap, reverse) = match rotation {
+            DisplayRotation::Rotate0 => (true, true),
+            DisplayRotation::Rotate90 => (false, true),
+            DisplayRotation::Rotate180 => (false, false),
+            DisplayRotation::Rotate270 => (true, false),
+        };
 
-        Command::DisplayOn(false).send(&mut self.interface)?;
-        Command::DisplayClockDiv(0x8, 0x0).send(&mut self.interface)?;
-        Command::Multiplex(SIZE::HEIGHT - 1).send(&mut self.interface)?;
-        Command::DisplayOffset(0).send(&mut self.interface)?;
-        Command::StartLine(0).send(&mut self.interface)?;
-        // TODO: Ability to turn charge pump on/off
-        Command::ChargePump(true).send(&mut self.interface)?;
-        Command::AddressMode(mode).send(&mut self.interface)?;
-
-        self.size.configure(&mut self.interface)?;
-        self.set_rotation(rotation)?;
-
-        self.set_brightness(Brightness::default())?;
-        Command::VcomhDeselect(VcomhLevel::Auto).send(&mut self.interface)?;
-        Command::AllOn(false).send(&mut self.interface)?;
-        Command::Invert(false).send(&mut self.interface)?;
-        Command::EnableScroll(false).send(&mut self.interface)?;
-        Command::DisplayOn(true).send(&mut self.interface)?;
-
-        self.addr_mode = mode;
-
-        Ok(())
+        [
+            Command::SegmentRemap(remap),
+            Command::ReverseComDir(reverse),
+        ]
     }
 
-    /// Change the addressing mode
-    pub fn set_addr_mode(&mut self, mode: AddrMode) -> Result<(), DisplayError> {
-        Command::AddressMode(mode).send(&mut self.interface)?;
-        self.addr_mode = mode;
-        Ok(())
+    fn mirror_commands(&self, mirror: bool) -> [Command; 2] {
+        if mirror {
+            let (remap, reverse) = match self.rotation {
+                DisplayRotation::Rotate0 => (false, true),
+                DisplayRotation::Rotate90 => (false, false),
+                DisplayRotation::Rotate180 => (true, false),
+                DisplayRotation::Rotate270 => (true, true),
+            };
+
+            [
+                Command::SegmentRemap(remap),
+                Command::ReverseComDir(reverse),
+            ]
+        } else {
+            self.rotation_commands(self.rotation)
+        }
     }
 
-    /// Send the data to the display for drawing at the current position in the framebuffer
-    /// and advance the position accordingly. Cf. `set_draw_area` to modify the affected area by
-    /// this method.
-    ///
-    /// This method takes advantage of a bounding box for faster writes.
-    pub fn bounded_draw(
-        &mut self,
-        buffer: &[u8],
+    fn brightness_commands(&self, brightness: Brightness) -> [Command; 2] {
+        [
+            Command::PreChargePeriod(1, brightness.precharge),
+            Command::Contrast(brightness.contrast),
+        ]
+    }
+
+    fn init_commands(&self, mode: AddrMode) -> [Command; 18] {
+        [
+            Command::DisplayOn(false),
+            Command::DisplayClockDiv(0x8, 0x0),
+            Command::Multiplex(SIZE::HEIGHT - 1),
+            Command::DisplayOffset(0),
+            Command::StartLine(0),
+            // TODO: Ability to turn charge pump on/off
+            Command::ChargePump(true),
+            Command::AddressMode(mode),
+            self.size.commands()[0],
+            self.size.commands()[1],
+            self.rotation_commands(self.rotation)[0],
+            self.rotation_commands(self.rotation)[1],
+            self.brightness_commands(Brightness::default())[0],
+            self.brightness_commands(Brightness::default())[1],
+            Command::VcomhDeselect(VcomhLevel::Auto),
+            Command::AllOn(false),
+            Command::Invert(false),
+            Command::EnableScroll(false),
+            Command::DisplayOn(true),
+        ]
+    }
+
+    fn draw_area_commands(&self, start: (u8, u8), end: (u8, u8)) -> [Command; 2] {
+        [
+            Command::ColumnAddress(start.0, end.0.saturating_sub(1)),
+            if self.addr_mode != AddrMode::Page {
+                Command::PageAddress(start.1.into(), (end.1.saturating_sub(1)).into())
+            } else {
+                Command::FastNoop
+            },
+        ]
+    }
+
+    fn buffer_chunks<'a>(
+        buffer: &'a [u8],
         disp_width: usize,
         upper_left: (u8, u8),
         lower_right: (u8, u8),
-    ) -> Result<(), DisplayError> {
-        Self::flush_buffer_chunks(
-            &mut self.interface,
-            buffer,
-            disp_width,
-            upper_left,
-            lower_right,
-        )
-    }
+    ) -> impl Iterator<Item = &'a [u8]> {
+        // Divide by 8 since each row is actually 8 pixels tall
+        let num_pages = ((lower_right.1 - upper_left.1) / 8) as usize + 1;
 
-    /// Send a raw buffer to the display.
-    pub fn draw(&mut self, buffer: &[u8]) -> Result<(), DisplayError> {
-        self.interface.send_data(U8(&buffer))
+        // Each page is 8 bits tall, so calculate which page number to start at (rounded down) from
+        // the top of the display
+        let starting_page = (upper_left.1 / 8) as usize;
+
+        // Calculate start and end X coordinates for each page
+        let page_lower = upper_left.0 as usize;
+        let page_upper = lower_right.0 as usize;
+
+        buffer
+            .chunks(disp_width)
+            .skip(starting_page)
+            .take(num_pages)
+            .map(move |s| &s[page_lower..page_upper])
     }
 
     /// Get display dimensions, taking into account the current rotation of the display
@@ -288,90 +323,98 @@ where
     pub fn rotation(&self) -> DisplayRotation {
         self.rotation
     }
+}
+
+impl<DI, SIZE, MODE> Ssd1306<DI, SIZE, MODE>
+where
+    DI: WriteOnlyDataCommand,
+    SIZE: DisplaySize,
+{
+    fn send_commands(&mut self, commands: &[Command]) -> Result<(), DisplayError> {
+        for command in commands {
+            command.send(&mut self.interface)?;
+        }
+
+        Ok(())
+    }
+
+    /// Initialise the display in one of the available addressing modes.
+    pub fn init_with_addr_mode(&mut self, mode: AddrMode) -> Result<(), DisplayError> {
+        self.send_commands(&self.init_commands(mode))?;
+        self.addr_mode = mode;
+
+        Ok(())
+    }
+
+    /// Change the addressing mode
+    pub fn set_addr_mode(&mut self, mode: AddrMode) -> Result<(), DisplayError> {
+        self.send_commands(&[Command::AddressMode(mode)])?;
+        self.addr_mode = mode;
+
+        Ok(())
+    }
+
+    /// Send the data to the display for drawing at the current position in the framebuffer
+    /// and advance the position accordingly. Cf. `set_draw_area` to modify the affected area by
+    /// this method.
+    ///
+    /// This method takes advantage of a bounding box for faster writes.
+    pub fn bounded_draw(
+        &mut self,
+        buffer: &[u8],
+        disp_width: usize,
+        upper_left: (u8, u8),
+        lower_right: (u8, u8),
+    ) -> Result<(), DisplayError> {
+        Self::flush_buffer_chunks(
+            &mut self.interface,
+            buffer,
+            disp_width,
+            upper_left,
+            lower_right,
+        )
+    }
+
+    /// Send a raw buffer to the display.
+    pub fn draw(&mut self, buffer: &[u8]) -> Result<(), DisplayError> {
+        self.interface.send_data(U8(&buffer))
+    }
 
     /// Set the display rotation.
     pub fn set_rotation(&mut self, rotation: DisplayRotation) -> Result<(), DisplayError> {
+        self.send_commands(&self.rotation_commands(rotation))?;
         self.rotation = rotation;
-
-        match rotation {
-            DisplayRotation::Rotate0 => {
-                Command::SegmentRemap(true).send(&mut self.interface)?;
-                Command::ReverseComDir(true).send(&mut self.interface)?;
-            }
-            DisplayRotation::Rotate90 => {
-                Command::SegmentRemap(false).send(&mut self.interface)?;
-                Command::ReverseComDir(true).send(&mut self.interface)?;
-            }
-            DisplayRotation::Rotate180 => {
-                Command::SegmentRemap(false).send(&mut self.interface)?;
-                Command::ReverseComDir(false).send(&mut self.interface)?;
-            }
-            DisplayRotation::Rotate270 => {
-                Command::SegmentRemap(true).send(&mut self.interface)?;
-                Command::ReverseComDir(false).send(&mut self.interface)?;
-            }
-        };
 
         Ok(())
     }
 
     /// Set mirror enabled/disabled.
     pub fn set_mirror(&mut self, mirror: bool) -> Result<(), DisplayError> {
-        if mirror {
-            match self.rotation {
-                DisplayRotation::Rotate0 => {
-                    Command::SegmentRemap(false).send(&mut self.interface)?;
-                    Command::ReverseComDir(true).send(&mut self.interface)?;
-                }
-                DisplayRotation::Rotate90 => {
-                    Command::SegmentRemap(false).send(&mut self.interface)?;
-                    Command::ReverseComDir(false).send(&mut self.interface)?;
-                }
-                DisplayRotation::Rotate180 => {
-                    Command::SegmentRemap(true).send(&mut self.interface)?;
-                    Command::ReverseComDir(false).send(&mut self.interface)?;
-                }
-                DisplayRotation::Rotate270 => {
-                    Command::SegmentRemap(true).send(&mut self.interface)?;
-                    Command::ReverseComDir(true).send(&mut self.interface)?;
-                }
-            };
-        } else {
-            self.set_rotation(self.rotation)?;
-        }
-        Ok(())
+        self.send_commands(&self.mirror_commands(mirror))
     }
 
     /// Change the display brightness.
     pub fn set_brightness(&mut self, brightness: Brightness) -> Result<(), DisplayError> {
-        Command::PreChargePeriod(1, brightness.precharge).send(&mut self.interface)?;
-        Command::Contrast(brightness.contrast).send(&mut self.interface)
+        self.send_commands(&self.brightness_commands(brightness))
     }
 
     /// Turn the display on or off. The display can be drawn to and retains all
     /// of its memory even while off.
     pub fn set_display_on(&mut self, on: bool) -> Result<(), DisplayError> {
-        Command::DisplayOn(on).send(&mut self.interface)
+        self.send_commands(&[Command::DisplayOn(on)])
     }
 
     /// Set the position in the framebuffer of the display limiting where any sent data should be
     /// drawn. This method can be used for changing the affected area on the screen as well
     /// as (re-)setting the start point of the next `draw` call.
     pub fn set_draw_area(&mut self, start: (u8, u8), end: (u8, u8)) -> Result<(), DisplayError> {
-        Command::ColumnAddress(start.0, end.0.saturating_sub(1)).send(&mut self.interface)?;
-
-        if self.addr_mode != AddrMode::Page {
-            Command::PageAddress(start.1.into(), (end.1.saturating_sub(1)).into())
-                .send(&mut self.interface)?;
-        }
-
-        Ok(())
+        self.send_commands(&self.draw_area_commands(start, end))
     }
 
     /// Set the column address in the framebuffer of the display where any sent data should be
     /// drawn.
     pub fn set_column(&mut self, column: u8) -> Result<(), DisplayError> {
-        Command::ColStart(column).send(&mut self.interface)
+        self.send_commands(&[Command::ColStart(column)])
     }
 
     /// Set the page address (row 8px high) in the framebuffer of the display where any sent data
@@ -380,7 +423,7 @@ where
     /// Note that the parameter is in pixels, but the page will be set to the start of the 8px
     /// row which contains the passed-in row.
     pub fn set_row(&mut self, row: u8) -> Result<(), DisplayError> {
-        Command::PageStart(row.into()).send(&mut self.interface)
+        self.send_commands(&[Command::PageStart(row.into())])
     }
 
     fn flush_buffer_chunks(
@@ -390,22 +433,7 @@ where
         upper_left: (u8, u8),
         lower_right: (u8, u8),
     ) -> Result<(), DisplayError> {
-        // Divide by 8 since each row is actually 8 pixels tall
-        let num_pages = ((lower_right.1 - upper_left.1) / 8) as usize + 1;
-
-        // Each page is 8 bits tall, so calculate which page number to start at (rounded down) from
-        // the top of the display
-        let starting_page = (upper_left.1 / 8) as usize;
-
-        // Calculate start and end X coordinates for each page
-        let page_lower = upper_left.0 as usize;
-        let page_upper = lower_right.0 as usize;
-
-        buffer
-            .chunks(disp_width)
-            .skip(starting_page)
-            .take(num_pages)
-            .map(|s| &s[page_lower..page_upper])
+        Self::buffer_chunks(buffer, disp_width, upper_left, lower_right)
             .try_for_each(|c| interface.send_data(U8(&c)))
     }
 }

--- a/src/mode/buffered_graphics.rs
+++ b/src/mode/buffered_graphics.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     command::AddrMode,
+    mode::DisplayConfig,
     rotation::DisplayRotation,
     size::{DisplaySize, NewZeroed},
     Ssd1306,
@@ -65,7 +66,6 @@ where
 
 impl<DI, SIZE> Ssd1306<DI, SIZE, BufferedGraphicsMode<SIZE>>
 where
-    DI: WriteOnlyDataCommand,
     SIZE: DisplaySize,
 {
     fn clear_impl(&mut self, value: bool) {
@@ -81,79 +81,6 @@ where
     /// Clear the underlying framebuffer. You need to call `disp.flush()` for any effect on the screen.
     pub fn clear_buffer(&mut self) {
         self.clear_impl(false);
-    }
-
-    /// Write out data to a display.
-    ///
-    /// This only updates the parts of the display that have changed since the last flush.
-    pub fn flush(&mut self) -> Result<(), DisplayError> {
-        // Nothing to do if no pixels have changed since the last update
-        if self.mode.max_x < self.mode.min_x || self.mode.max_y < self.mode.min_y {
-            return Ok(());
-        }
-
-        let (width, height) = self.dimensions();
-
-        // Determine which bytes need to be sent
-        let disp_min_x = self.mode.min_x;
-        let disp_min_y = self.mode.min_y;
-
-        let (disp_max_x, disp_max_y) = match self.rotation {
-            DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => (
-                (self.mode.max_x + 1).min(width),
-                (self.mode.max_y | 7).min(height),
-            ),
-            DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => (
-                (self.mode.max_x | 7).min(width),
-                (self.mode.max_y + 1).min(height),
-            ),
-        };
-
-        self.mode.min_x = 255;
-        self.mode.max_x = 0;
-        self.mode.min_y = 255;
-        self.mode.max_y = 0;
-
-        // Tell the display to update only the part that has changed
-        let offset_x = match self.rotation {
-            DisplayRotation::Rotate0 | DisplayRotation::Rotate270 => SIZE::OFFSETX,
-            DisplayRotation::Rotate180 | DisplayRotation::Rotate90 => {
-                // If segment remapping is flipped, we need to calculate
-                // the offset from the other edge of the display.
-                SIZE::DRIVER_COLS - SIZE::WIDTH - SIZE::OFFSETX
-            }
-        };
-
-        match self.rotation {
-            DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => {
-                self.set_draw_area(
-                    (disp_min_x + offset_x, disp_min_y + SIZE::OFFSETY),
-                    (disp_max_x + offset_x, disp_max_y + SIZE::OFFSETY),
-                )?;
-
-                Self::flush_buffer_chunks(
-                    &mut self.interface,
-                    self.mode.buffer.as_mut(),
-                    width as usize,
-                    (disp_min_x, disp_min_y),
-                    (disp_max_x, disp_max_y),
-                )
-            }
-            DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => {
-                self.set_draw_area(
-                    (disp_min_y + offset_x, disp_min_x + SIZE::OFFSETY),
-                    (disp_max_y + offset_x, disp_max_x + SIZE::OFFSETY),
-                )?;
-
-                Self::flush_buffer_chunks(
-                    &mut self.interface,
-                    self.mode.buffer.as_mut(),
-                    height as usize,
-                    (disp_min_y, disp_min_x),
-                    (disp_max_y, disp_max_x),
-                )
-            }
-        }
     }
 
     /// Turn a pixel on or off. A non-zero `value` is treated as on, `0` as off. If the X and Y
@@ -190,6 +117,89 @@ where
             *byte = *byte & !(1 << bit) | (value << bit)
         }
     }
+
+    fn dirty_area(&self, width: u8, height: u8) -> ((u8, u8), (u8, u8)) {
+        let min = (self.mode.min_x, self.mode.min_y);
+        let max = match self.rotation {
+            DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => (
+                (self.mode.max_x + 1).min(width),
+                (self.mode.max_y | 7).min(height),
+            ),
+            DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => (
+                (self.mode.max_x | 7).min(width),
+                (self.mode.max_y + 1).min(height),
+            ),
+        };
+
+        (min, max)
+    }
+
+    fn display_area(&self, disp_min: (u8, u8), disp_max: (u8, u8)) -> ((u8, u8), (u8, u8)) {
+        let offset_x = match self.rotation {
+            DisplayRotation::Rotate0 | DisplayRotation::Rotate270 => SIZE::OFFSETX,
+            DisplayRotation::Rotate180 | DisplayRotation::Rotate90 => {
+                // If segment remapping is flipped, we need to calculate
+                // the offset from the other edge of the display.
+                SIZE::DRIVER_COLS - SIZE::WIDTH - SIZE::OFFSETX
+            }
+        };
+
+        match self.rotation {
+            DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => (
+                (disp_min.0 + offset_x, disp_min.1 + SIZE::OFFSETY),
+                (disp_max.0 + offset_x, disp_max.1 + SIZE::OFFSETY),
+            ),
+            DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => (
+                (disp_min.1 + offset_x, disp_min.0 + SIZE::OFFSETY),
+                (disp_max.1 + offset_x, disp_max.0 + SIZE::OFFSETY),
+            ),
+        }
+    }
+}
+
+impl<DI, SIZE> Ssd1306<DI, SIZE, BufferedGraphicsMode<SIZE>>
+where
+    DI: WriteOnlyDataCommand,
+    SIZE: DisplaySize,
+{
+    /// Write out data to a display.
+    ///
+    /// This only updates the parts of the display that have changed since the last flush.
+    pub fn flush(&mut self) -> Result<(), DisplayError> {
+        // Nothing to do if no pixels have changed since the last update
+        if self.mode.max_x < self.mode.min_x || self.mode.max_y < self.mode.min_y {
+            return Ok(());
+        }
+
+        let (width, height) = self.dimensions();
+        let (disp_min, disp_max) = self.dirty_area(width, height);
+        let (area_start, area_end) = self.display_area(disp_min, disp_max);
+
+        self.mode.min_x = 255;
+        self.mode.max_x = 0;
+        self.mode.min_y = 255;
+        self.mode.max_y = 0;
+
+        // Tell the display to update only the part that has changed
+        self.set_draw_area(area_start, area_end)?;
+
+        match self.rotation {
+            DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => Self::flush_buffer_chunks(
+                &mut self.interface,
+                self.mode.buffer.as_mut(),
+                width as usize,
+                (disp_min.0, disp_min.1),
+                (disp_max.0, disp_max.1),
+            ),
+            DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => Self::flush_buffer_chunks(
+                &mut self.interface,
+                self.mode.buffer.as_mut(),
+                height as usize,
+                (disp_min.1, disp_min.0),
+                (disp_max.1, disp_max.0),
+            ),
+        }
+    }
 }
 
 #[cfg(feature = "graphics")]
@@ -201,12 +211,9 @@ use embedded_graphics_core::{
     Pixel,
 };
 
-use super::DisplayConfig;
-
 #[cfg(feature = "graphics")]
 impl<DI, SIZE> DrawTarget for Ssd1306<DI, SIZE, BufferedGraphicsMode<SIZE>>
 where
-    DI: WriteOnlyDataCommand,
     SIZE: DisplaySize,
 {
     type Color = BinaryColor;
@@ -237,7 +244,6 @@ where
 #[cfg(feature = "graphics")]
 impl<DI, SIZE> OriginDimensions for Ssd1306<DI, SIZE, BufferedGraphicsMode<SIZE>>
 where
-    DI: WriteOnlyDataCommand,
     SIZE: DisplaySize,
 {
     fn size(&self) -> Size {

--- a/src/size.rs
+++ b/src/size.rs
@@ -47,7 +47,15 @@ pub trait DisplaySize {
     /// See [`Command::ComPinConfig`](crate::Command::ComPinConfig)
     /// and [`Command::InternalIref`](crate::Command::InternalIref)
     /// for more information
-    fn configure(&self, iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError>;
+    fn configure(&self, iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
+        for command in self.commands() {
+            command.send(iface)?;
+        }
+        Ok(())
+    }
+
+    /// Returns the set of resolution and model-dependent configuration commands
+    fn commands(&self) -> [Command; 2];
 }
 
 /// Size information for the common 128x64 variants
@@ -58,8 +66,8 @@ impl DisplaySize for DisplaySize128x64 {
     const HEIGHT: u8 = 64;
     type Buffer = [u8; Self::WIDTH as usize * Self::HEIGHT as usize / 8];
 
-    fn configure(&self, iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
-        Command::ComPinConfig(true, false).send(iface)
+    fn commands(&self) -> [Command; 2] {
+        [Command::ComPinConfig(true, false), Command::FastNoop]
     }
 }
 
@@ -71,8 +79,8 @@ impl DisplaySize for DisplaySize128x32 {
     const HEIGHT: u8 = 32;
     type Buffer = [u8; Self::WIDTH as usize * Self::HEIGHT as usize / 8];
 
-    fn configure(&self, iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
-        Command::ComPinConfig(false, false).send(iface)
+    fn commands(&self) -> [Command; 2] {
+        [Command::ComPinConfig(false, false), Command::FastNoop]
     }
 }
 
@@ -84,8 +92,8 @@ impl DisplaySize for DisplaySize96x16 {
     const HEIGHT: u8 = 16;
     type Buffer = [u8; Self::WIDTH as usize * Self::HEIGHT as usize / 8];
 
-    fn configure(&self, iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
-        Command::ComPinConfig(false, false).send(iface)
+    fn commands(&self) -> [Command; 2] {
+        [Command::ComPinConfig(false, false), Command::FastNoop]
     }
 }
 
@@ -99,9 +107,11 @@ impl DisplaySize for DisplaySize72x40 {
     const OFFSETY: u8 = 0;
     type Buffer = [u8; Self::WIDTH as usize * Self::HEIGHT as usize / 8];
 
-    fn configure(&self, iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
-        Command::ComPinConfig(true, false).send(iface)?;
-        Command::InternalIref(true, true).send(iface)
+    fn commands(&self) -> [Command; 2] {
+        [
+            Command::ComPinConfig(true, false),
+            Command::InternalIref(true, true),
+        ]
     }
 }
 
@@ -115,8 +125,8 @@ impl DisplaySize for DisplaySize64x48 {
     const OFFSETY: u8 = 0;
     type Buffer = [u8; Self::WIDTH as usize * Self::HEIGHT as usize / 8];
 
-    fn configure(&self, iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
-        Command::ComPinConfig(true, false).send(iface)
+    fn commands(&self) -> [Command; 2] {
+        [Command::ComPinConfig(true, false), Command::FastNoop]
     }
 }
 
@@ -130,7 +140,7 @@ impl DisplaySize for DisplaySize64x32 {
     const OFFSETY: u8 = 0;
     type Buffer = [u8; Self::WIDTH as usize * Self::HEIGHT as usize / 8];
 
-    fn configure(&self, iface: &mut impl WriteOnlyDataCommand) -> Result<(), DisplayError> {
-        Command::ComPinConfig(true, false).send(iface)
+    fn commands(&self) -> [Command; 2] {
+        [Command::ComPinConfig(true, false), Command::FastNoop]
     }
 }


### PR DESCRIPTION
Hi! Thank you for helping out with SSD1306 development! Please:

- [x] Check that you've added documentation to any new methods
- [x] Rebase from `master` if you're not already up to date
- [x] Add or modify an example if there are changes to the public API
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, **Changed**, etc)
- [x] Run `rustfmt` on the project with `cargo fmt --all` - CI will not pass without this step
- [x] Check that your branch is up to date with master and that CI is passing once the PR is opened

## PR description

Some code doesn't rely on the display interface. This PR moves these to impl blocks that don't restrict DI to any particular trait. While this isn't immediately useful, this refactor will help in avoiding code duplication.

I've added `FastNoop` instead of short circuiting the current `Noop` command just in case someone relies on the current command's details. [Backwards compatibility](https://xkcd.com/1172/) FTW. `FastNoop` is currently used to fill out Command arrays where a particular option requires less elements than the array's capacity.

Warning: some of my decisions may be controversial.