### PR TITLE
Modernize examples

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 target_steps: &target_steps
   docker:
-    - image: cimg/rust:1.57.0
+    - image: cimg/rust:1.61.0
   steps:
     - checkout
     - restore_cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Changed
 
-- **(breaking)** [#175](https://github.com/jamwaffles/ssd1306/pull/175) Increased MSRV to 1.57.0
+- **(breaking)** [#184](https://github.com/jamwaffles/ssd1306/pull/184) Increased MSRV to 1.61.0
 - **(breaking)** [#179](https://github.com/jamwaffles/ssd1306/pull/179) Changed `Ssd1306::reset` signature.
 
 ## [0.7.1] - 2022-08-15

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/jamwaffles/ssd1306"
 version = "0.7.1"
 edition = "2018"
 exclude = [ "build.rs", "build.sh", "memory.x", "doc", "*.jpg", "*.png", "*.bmp" ]
-rust-version = "1.57"
+rust-version = "1.61"
 
 [badges]
 circle-ci = { repository = "jamwaffles/ssd1306", branch = "master" }
@@ -28,8 +28,8 @@ embedded-graphics-core = { version = "0.3.2", optional = true }
 
 [dev-dependencies]
 cortex-m = "0.7.2"
-cortex-m-rt = "0.6.14"
-cortex-m-rtic = "0.5.6"
+cortex-m-rt = "0.7.3"
+cortex-m-rtic = "1.1.4"
 panic-halt = "0.2.0"
 cast = { version = "0.2.6", default-features = false }
 # Used to load BMP images in various examples
@@ -37,7 +37,7 @@ tinybmp = "0.3.1"
 embedded-graphics = "0.7.1"
 # Used by the noise_i2c examples
 rand = { version = "0.8.4", default-features = false, features = [ "small_rng" ] }
-stm32f1xx-hal = { version = "0.7.0", features = [ "rt", "stm32f103" ] }
+stm32f1xx-hal = { version = "0.10.0", features = [ "rt", "stm32f103" ] }
 
 [features]
 default = ["graphics"]

--- a/examples/bmp_i2c.rs
+++ b/examples/bmp_i2c.rs
@@ -37,13 +37,13 @@ fn main() -> ! {
     let dp = stm32::Peripherals::take().unwrap();
 
     let mut flash = dp.FLASH.constrain();
-    let mut rcc = dp.RCC.constrain();
+    let rcc = dp.RCC.constrain();
 
     let clocks = rcc.cfgr.freeze(&mut flash.acr);
 
-    let mut afio = dp.AFIO.constrain(&mut rcc.apb2);
+    let mut afio = dp.AFIO.constrain();
 
-    let mut gpiob = dp.GPIOB.split(&mut rcc.apb2);
+    let mut gpiob = dp.GPIOB.split();
 
     let scl = gpiob.pb8.into_alternate_open_drain(&mut gpiob.crh);
     let sda = gpiob.pb9.into_alternate_open_drain(&mut gpiob.crh);
@@ -53,11 +53,10 @@ fn main() -> ! {
         (scl, sda),
         &mut afio.mapr,
         Mode::Fast {
-            frequency: 400_000.hz(),
+            frequency: 400_000.Hz(),
             duty_cycle: DutyCycle::Ratio2to1,
         },
         clocks,
-        &mut rcc.apb1,
         1000,
         10,
         1000,
@@ -85,6 +84,6 @@ fn main() -> ! {
 }
 
 #[exception]
-fn HardFault(ef: &ExceptionFrame) -> ! {
+unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
     panic!("{:#?}", ef);
 }

--- a/examples/graphics.rs
+++ b/examples/graphics.rs
@@ -29,10 +29,10 @@ use embedded_graphics::{
 use panic_halt as _;
 use ssd1306::{prelude::*, Ssd1306};
 use stm32f1xx_hal::{
-    delay::Delay,
     prelude::*,
     spi::{Mode, Phase, Polarity, Spi},
     stm32,
+    timer::Timer,
 };
 
 #[entry]
@@ -41,21 +41,21 @@ fn main() -> ! {
     let dp = stm32::Peripherals::take().unwrap();
 
     let mut flash = dp.FLASH.constrain();
-    let mut rcc = dp.RCC.constrain();
+    let rcc = dp.RCC.constrain();
 
     let clocks = rcc.cfgr.freeze(&mut flash.acr);
 
-    let mut afio = dp.AFIO.constrain(&mut rcc.apb2);
+    let mut afio = dp.AFIO.constrain();
 
-    let mut gpioa = dp.GPIOA.split(&mut rcc.apb2);
-    let mut gpiob = dp.GPIOB.split(&mut rcc.apb2);
+    let mut gpioa = dp.GPIOA.split();
+    let mut gpiob = dp.GPIOB.split();
 
     // SPI1
     let sck = gpioa.pa5.into_alternate_push_pull(&mut gpioa.crl);
     let miso = gpioa.pa6;
     let mosi = gpioa.pa7.into_alternate_push_pull(&mut gpioa.crl);
 
-    let mut delay = Delay::new(cp.SYST, clocks);
+    let mut delay = Timer::syst(cp.SYST, &clocks).delay();
 
     let mut rst = gpiob.pb0.into_push_pull_output(&mut gpiob.crl);
     let dc = gpiob.pb1.into_push_pull_output(&mut gpiob.crl);
@@ -68,9 +68,8 @@ fn main() -> ! {
             polarity: Polarity::IdleLow,
             phase: Phase::CaptureOnFirstTransition,
         },
-        8.mhz(),
+        8.MHz(),
         clocks,
-        &mut rcc.apb2,
     );
 
     let interface = display_interface_spi::SPIInterfaceNoCS::new(spi, dc);
@@ -123,6 +122,6 @@ fn main() -> ! {
 }
 
 #[exception]
-fn HardFault(ef: &ExceptionFrame) -> ! {
+unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
     panic!("{:#?}", ef);
 }

--- a/examples/graphics_i2c.rs
+++ b/examples/graphics_i2c.rs
@@ -36,13 +36,13 @@ fn main() -> ! {
     let dp = stm32::Peripherals::take().unwrap();
 
     let mut flash = dp.FLASH.constrain();
-    let mut rcc = dp.RCC.constrain();
+    let rcc = dp.RCC.constrain();
 
     let clocks = rcc.cfgr.freeze(&mut flash.acr);
 
-    let mut afio = dp.AFIO.constrain(&mut rcc.apb2);
+    let mut afio = dp.AFIO.constrain();
 
-    let mut gpiob = dp.GPIOB.split(&mut rcc.apb2);
+    let mut gpiob = dp.GPIOB.split();
 
     let scl = gpiob.pb8.into_alternate_open_drain(&mut gpiob.crh);
     let sda = gpiob.pb9.into_alternate_open_drain(&mut gpiob.crh);
@@ -52,11 +52,10 @@ fn main() -> ! {
         (scl, sda),
         &mut afio.mapr,
         Mode::Fast {
-            frequency: 400_000.hz(),
+            frequency: 400_000.Hz(),
             duty_cycle: DutyCycle::Ratio2to1,
         },
         clocks,
-        &mut rcc.apb1,
         1000,
         10,
         1000,
@@ -111,6 +110,6 @@ fn main() -> ! {
 }
 
 #[exception]
-fn HardFault(ef: &ExceptionFrame) -> ! {
+unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
     panic!("{:#?}", ef);
 }

--- a/examples/graphics_i2c_128x32.rs
+++ b/examples/graphics_i2c_128x32.rs
@@ -36,13 +36,13 @@ fn main() -> ! {
     let dp = stm32::Peripherals::take().unwrap();
 
     let mut flash = dp.FLASH.constrain();
-    let mut rcc = dp.RCC.constrain();
+    let rcc = dp.RCC.constrain();
 
     let clocks = rcc.cfgr.freeze(&mut flash.acr);
 
-    let mut afio = dp.AFIO.constrain(&mut rcc.apb2);
+    let mut afio = dp.AFIO.constrain();
 
-    let mut gpiob = dp.GPIOB.split(&mut rcc.apb2);
+    let mut gpiob = dp.GPIOB.split();
 
     let scl = gpiob.pb8.into_alternate_open_drain(&mut gpiob.crh);
     let sda = gpiob.pb9.into_alternate_open_drain(&mut gpiob.crh);
@@ -52,11 +52,10 @@ fn main() -> ! {
         (scl, sda),
         &mut afio.mapr,
         Mode::Fast {
-            frequency: 400_000.hz(),
+            frequency: 400_000.Hz(),
             duty_cycle: DutyCycle::Ratio2to1,
         },
         clocks,
-        &mut rcc.apb1,
         1000,
         10,
         1000,
@@ -111,6 +110,6 @@ fn main() -> ! {
 }
 
 #[exception]
-fn HardFault(ef: &ExceptionFrame) -> ! {
+unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
     panic!("{:#?}", ef);
 }

--- a/examples/graphics_i2c_72x40.rs
+++ b/examples/graphics_i2c_72x40.rs
@@ -36,13 +36,13 @@ fn main() -> ! {
     let dp = stm32::Peripherals::take().unwrap();
 
     let mut flash = dp.FLASH.constrain();
-    let mut rcc = dp.RCC.constrain();
+    let rcc = dp.RCC.constrain();
 
     let clocks = rcc.cfgr.freeze(&mut flash.acr);
 
-    let mut afio = dp.AFIO.constrain(&mut rcc.apb2);
+    let mut afio = dp.AFIO.constrain();
 
-    let mut gpiob = dp.GPIOB.split(&mut rcc.apb2);
+    let mut gpiob = dp.GPIOB.split();
 
     let scl = gpiob.pb8.into_alternate_open_drain(&mut gpiob.crh);
     let sda = gpiob.pb9.into_alternate_open_drain(&mut gpiob.crh);
@@ -52,11 +52,10 @@ fn main() -> ! {
         (scl, sda),
         &mut afio.mapr,
         Mode::Fast {
-            frequency: 400_000.hz(),
+            frequency: 400_000.Hz(),
             duty_cycle: DutyCycle::Ratio2to1,
         },
         clocks,
-        &mut rcc.apb1,
         1000,
         10,
         1000,
@@ -122,6 +121,6 @@ fn main() -> ! {
 }
 
 #[exception]
-fn HardFault(ef: &ExceptionFrame) -> ! {
+unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
     panic!("{:#?}", ef);
 }

--- a/examples/image_i2c.rs
+++ b/examples/image_i2c.rs
@@ -42,13 +42,13 @@ fn main() -> ! {
     let dp = stm32::Peripherals::take().unwrap();
 
     let mut flash = dp.FLASH.constrain();
-    let mut rcc = dp.RCC.constrain();
+    let rcc = dp.RCC.constrain();
 
     let clocks = rcc.cfgr.freeze(&mut flash.acr);
 
-    let mut afio = dp.AFIO.constrain(&mut rcc.apb2);
+    let mut afio = dp.AFIO.constrain();
 
-    let mut gpiob = dp.GPIOB.split(&mut rcc.apb2);
+    let mut gpiob = dp.GPIOB.split();
 
     let scl = gpiob.pb8.into_alternate_open_drain(&mut gpiob.crh);
     let sda = gpiob.pb9.into_alternate_open_drain(&mut gpiob.crh);
@@ -58,11 +58,10 @@ fn main() -> ! {
         (scl, sda),
         &mut afio.mapr,
         Mode::Fast {
-            frequency: 400_000.hz(),
+            frequency: 400_000.Hz(),
             duty_cycle: DutyCycle::Ratio2to1,
         },
         clocks,
-        &mut rcc.apb1,
         1000,
         10,
         1000,
@@ -86,6 +85,6 @@ fn main() -> ! {
 }
 
 #[exception]
-fn HardFault(ef: &ExceptionFrame) -> ! {
+unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
     panic!("{:#?}", ef);
 }

--- a/examples/noise_i2c.rs
+++ b/examples/noise_i2c.rs
@@ -34,13 +34,13 @@ fn main() -> ! {
     let dp = stm32::Peripherals::take().unwrap();
 
     let mut flash = dp.FLASH.constrain();
-    let mut rcc = dp.RCC.constrain();
+    let rcc = dp.RCC.constrain();
 
     let clocks = rcc.cfgr.freeze(&mut flash.acr);
 
-    let mut afio = dp.AFIO.constrain(&mut rcc.apb2);
+    let mut afio = dp.AFIO.constrain();
 
-    let mut gpiob = dp.GPIOB.split(&mut rcc.apb2);
+    let mut gpiob = dp.GPIOB.split();
 
     let scl = gpiob.pb8.into_alternate_open_drain(&mut gpiob.crh);
     let sda = gpiob.pb9.into_alternate_open_drain(&mut gpiob.crh);
@@ -50,11 +50,10 @@ fn main() -> ! {
         (scl, sda),
         &mut afio.mapr,
         Mode::Fast {
-            frequency: 400_000.hz(),
+            frequency: 400_000.Hz(),
             duty_cycle: DutyCycle::Ratio2to1,
         },
         clocks,
-        &mut rcc.apb1,
         1000,
         10,
         1000,
@@ -77,6 +76,6 @@ fn main() -> ! {
 }
 
 #[exception]
-fn HardFault(ef: &ExceptionFrame) -> ! {
+unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
     panic!("{:#?}", ef);
 }

--- a/examples/rotation_i2c.rs
+++ b/examples/rotation_i2c.rs
@@ -42,13 +42,13 @@ fn main() -> ! {
     let dp = stm32::Peripherals::take().unwrap();
 
     let mut flash = dp.FLASH.constrain();
-    let mut rcc = dp.RCC.constrain();
+    let rcc = dp.RCC.constrain();
 
     let clocks = rcc.cfgr.freeze(&mut flash.acr);
 
-    let mut afio = dp.AFIO.constrain(&mut rcc.apb2);
+    let mut afio = dp.AFIO.constrain();
 
-    let mut gpiob = dp.GPIOB.split(&mut rcc.apb2);
+    let mut gpiob = dp.GPIOB.split();
 
     let scl = gpiob.pb8.into_alternate_open_drain(&mut gpiob.crh);
     let sda = gpiob.pb9.into_alternate_open_drain(&mut gpiob.crh);
@@ -58,11 +58,10 @@ fn main() -> ! {
         (scl, sda),
         &mut afio.mapr,
         Mode::Fast {
-            frequency: 400_000.hz(),
+            frequency: 400_000.Hz(),
             duty_cycle: DutyCycle::Ratio2to1,
         },
         clocks,
-        &mut rcc.apb1,
         1000,
         10,
         1000,
@@ -95,6 +94,6 @@ fn main() -> ! {
 }
 
 #[exception]
-fn HardFault(ef: &ExceptionFrame) -> ! {
+unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
     panic!("{:#?}", ef);
 }

--- a/examples/rtic_brightness.rs
+++ b/examples/rtic_brightness.rs
@@ -6,50 +6,52 @@
 #![no_std]
 #![no_main]
 
-use display_interface_spi::SPIInterfaceNoCS;
-use embedded_graphics::{
-    geometry::Point,
-    image::Image,
-    pixelcolor::{BinaryColor, Rgb565},
-    prelude::*,
-    primitives::{PrimitiveStyle, Rectangle},
-};
-use panic_halt as _;
-use rtic::app;
-use ssd1306::{mode::BufferedGraphicsMode, prelude::*, Ssd1306};
-use stm32f1xx_hal::{
-    delay::Delay,
-    gpio,
-    pac::{self, SPI1},
-    prelude::*,
-    spi::{self, Mode, Phase, Polarity, Spi},
-    timer::{CountDownTimer, Event, Timer},
-};
-use tinybmp::Bmp;
+#[rtic::app(device = stm32f1xx_hal::pac, peripherals = true, dispatchers = [EXTI0])]
+mod app {
+    use display_interface_spi::SPIInterfaceNoCS;
+    use embedded_graphics::{
+        geometry::Point,
+        image::Image,
+        pixelcolor::{BinaryColor, Rgb565},
+        prelude::*,
+        primitives::{PrimitiveStyle, Rectangle},
+    };
+    use panic_halt as _;
+    use ssd1306::{mode::BufferedGraphicsMode, prelude::*, Ssd1306};
+    use stm32f1xx_hal::{
+        gpio,
+        pac::{self, SPI1},
+        prelude::*,
+        spi::{self, Mode, Phase, Polarity, Spi},
+        timer::{CounterMs, Event, Timer},
+    };
+    use tinybmp::Bmp;
 
-type Display = Ssd1306<
-    SPIInterfaceNoCS<
-        spi::Spi<
-            SPI1,
-            spi::Spi1NoRemap,
-            (
-                gpio::gpioa::PA5<gpio::Alternate<gpio::PushPull>>,
-                gpio::gpioa::PA6<gpio::Input<gpio::Floating>>,
-                gpio::gpioa::PA7<gpio::Alternate<gpio::PushPull>>,
-            ),
-            u8,
+    type Display = Ssd1306<
+        SPIInterfaceNoCS<
+            spi::Spi<
+                SPI1,
+                spi::Spi1NoRemap,
+                (
+                    gpio::gpioa::PA5<gpio::Alternate<gpio::PushPull>>,
+                    gpio::gpioa::PA6<gpio::Input<gpio::Floating>>,
+                    gpio::gpioa::PA7<gpio::Alternate<gpio::PushPull>>,
+                ),
+                u8,
+            >,
+            gpio::gpiob::PB1<gpio::Output<gpio::PushPull>>,
         >,
-        gpio::gpiob::PB1<gpio::Output<gpio::PushPull>>,
-    >,
-    DisplaySize128x64,
-    BufferedGraphicsMode<DisplaySize128x64>,
->;
+        DisplaySize128x64,
+        BufferedGraphicsMode<DisplaySize128x64>,
+    >;
 
-#[app(device = stm32f1xx_hal::pac, peripherals = true)]
-const APP: () = {
+    #[shared]
+    struct SharedResources {}
+
+    #[local]
     struct Resources {
         display: Display,
-        timer: CountDownTimer<pac::TIM1>,
+        timer: CounterMs<pac::TIM1>,
         top_left: Point,
         velocity: Point,
         bmp: Bmp<Rgb565, 'static>,
@@ -57,31 +59,31 @@ const APP: () = {
     }
 
     #[init]
-    fn init(cx: init::Context) -> init::LateResources {
+    fn init(cx: init::Context) -> (SharedResources, Resources, init::Monotonics) {
         let dp = cx.device;
         let core = cx.core;
 
         let mut flash = dp.FLASH.constrain();
-        let mut rcc = dp.RCC.constrain();
+        let rcc = dp.RCC.constrain();
 
         let clocks = rcc
             .cfgr
-            .use_hse(8.mhz())
-            .sysclk(72.mhz())
-            .pclk1(36.mhz())
+            .use_hse(8.MHz())
+            .sysclk(72.MHz())
+            .pclk1(36.MHz())
             .freeze(&mut flash.acr);
 
-        let mut afio = dp.AFIO.constrain(&mut rcc.apb2);
+        let mut afio = dp.AFIO.constrain();
 
-        let mut gpiob = dp.GPIOB.split(&mut rcc.apb2);
-        let mut gpioa = dp.GPIOA.split(&mut rcc.apb2);
+        let mut gpiob = dp.GPIOB.split();
+        let mut gpioa = dp.GPIOA.split();
 
         // SPI1
         let sck = gpioa.pa5.into_alternate_push_pull(&mut gpioa.crl);
         let miso = gpioa.pa6;
         let mosi = gpioa.pa7.into_alternate_push_pull(&mut gpioa.crl);
 
-        let mut delay = Delay::new(core.SYST, clocks);
+        let mut delay = Timer::syst(core.SYST, &clocks).delay();
 
         let mut rst = gpiob.pb0.into_push_pull_output(&mut gpiob.crl);
         let dc = gpiob.pb1.into_push_pull_output(&mut gpiob.crl);
@@ -94,9 +96,8 @@ const APP: () = {
                 polarity: Polarity::IdleLow,
                 phase: Phase::CaptureOnFirstTransition,
             },
-            8.mhz(),
+            8.MHz(),
             clocks,
-            &mut rcc.apb2,
         );
 
         let interface = display_interface_spi::SPIInterfaceNoCS::new(spi, dc);
@@ -107,28 +108,31 @@ const APP: () = {
         display.init().unwrap();
 
         // Update framerate
-        let fps = 20;
-
-        let mut timer = Timer::tim1(dp.TIM1, &clocks, &mut rcc.apb2).start_count_down(fps.hz());
+        let mut timer = dp.TIM1.counter_ms(&clocks);
+        timer.start(50.millis()).unwrap(); // 20 FPS
 
         timer.listen(Event::Update);
 
         let bmp = Bmp::from_slice(include_bytes!("dvd.bmp")).unwrap();
 
         // Init the static resources to use them later through RTIC
-        init::LateResources {
-            timer,
-            display,
-            top_left: Point::new(5, 3),
-            velocity: Point::new(1, 1),
-            bmp,
-            brightness: Brightness::default(),
-        }
+        (
+            SharedResources {},
+            Resources {
+                timer,
+                display,
+                top_left: Point::new(5, 3),
+                velocity: Point::new(1, 1),
+                bmp,
+                brightness: Brightness::default(),
+            },
+            init::Monotonics(),
+        )
     }
 
-    #[task(binds = TIM1_UP, resources = [display, top_left, velocity, timer, bmp, brightness])]
+    #[task(binds = TIM1_UP, local = [display, top_left, velocity, timer, bmp, brightness])]
     fn update(cx: update::Context) {
-        let update::Resources {
+        let update::LocalResources {
             display,
             top_left,
             velocity,
@@ -136,7 +140,7 @@ const APP: () = {
             bmp,
             brightness,
             ..
-        } = cx.resources;
+        } = cx.local;
 
         let bottom_right = *top_left + bmp.bounding_box().size;
 
@@ -187,10 +191,6 @@ const APP: () = {
         display.flush().unwrap();
 
         // Clears the update flag
-        timer.clear_update_interrupt_flag();
+        timer.clear_interrupt(Event::Update);
     }
-
-    extern "C" {
-        fn EXTI0();
-    }
-};
+}

--- a/examples/terminal_i2c.rs
+++ b/examples/terminal_i2c.rs
@@ -32,13 +32,13 @@ fn main() -> ! {
     let dp = stm32::Peripherals::take().unwrap();
 
     let mut flash = dp.FLASH.constrain();
-    let mut rcc = dp.RCC.constrain();
+    let rcc = dp.RCC.constrain();
 
     let clocks = rcc.cfgr.freeze(&mut flash.acr);
 
-    let mut afio = dp.AFIO.constrain(&mut rcc.apb2);
+    let mut afio = dp.AFIO.constrain();
 
-    let mut gpiob = dp.GPIOB.split(&mut rcc.apb2);
+    let mut gpiob = dp.GPIOB.split();
 
     let scl = gpiob.pb8.into_alternate_open_drain(&mut gpiob.crh);
     let sda = gpiob.pb9.into_alternate_open_drain(&mut gpiob.crh);
@@ -48,11 +48,10 @@ fn main() -> ! {
         (scl, sda),
         &mut afio.mapr,
         Mode::Fast {
-            frequency: 400_000.hz(),
+            frequency: 400_000.Hz(),
             duty_cycle: DutyCycle::Ratio2to1,
         },
         clocks,
-        &mut rcc.apb1,
         1000,
         10,
         1000,
@@ -77,6 +76,6 @@ fn main() -> ! {
 }
 
 #[exception]
-fn HardFault(ef: &ExceptionFrame) -> ! {
+unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
     panic!("{:#?}", ef);
 }

--- a/examples/text_i2c.rs
+++ b/examples/text_i2c.rs
@@ -38,13 +38,13 @@ fn main() -> ! {
     let dp = stm32::Peripherals::take().unwrap();
 
     let mut flash = dp.FLASH.constrain();
-    let mut rcc = dp.RCC.constrain();
+    let rcc = dp.RCC.constrain();
 
     let clocks = rcc.cfgr.freeze(&mut flash.acr);
 
-    let mut afio = dp.AFIO.constrain(&mut rcc.apb2);
+    let mut afio = dp.AFIO.constrain();
 
-    let mut gpiob = dp.GPIOB.split(&mut rcc.apb2);
+    let mut gpiob = dp.GPIOB.split();
 
     let scl = gpiob.pb8.into_alternate_open_drain(&mut gpiob.crh);
     let sda = gpiob.pb9.into_alternate_open_drain(&mut gpiob.crh);
@@ -54,11 +54,10 @@ fn main() -> ! {
         (scl, sda),
         &mut afio.mapr,
         Mode::Fast {
-            frequency: 400_000.hz(),
+            frequency: 400_000.Hz(),
             duty_cycle: DutyCycle::Ratio2to1,
         },
         clocks,
-        &mut rcc.apb1,
         1000,
         10,
         1000,
@@ -89,6 +88,6 @@ fn main() -> ! {
 }
 
 #[exception]
-fn HardFault(ef: &ExceptionFrame) -> ! {
+unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
     panic!("{:#?}", ef);
 }


### PR DESCRIPTION
This PR updates examples to the currently latest HAL/RTIC crates, making them relevant again. Hopefully, this provides a solid base for later embedded-hal 1.0 updates, too.

As I don't have an STM32F10x, I haven't been able to test them, but I'm confident in everything except the RTIC examples.