### PR TITLE
Fix `BufferedGraphicsMode::clear()` so that it fills all pixels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ SSD1306 monochrome OLED display.
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+- Fixed `BufferedGraphicsMode::clear(On)` such that it fills all pixels with `On`, not only some.
+
 ## [0.8.3] - 2023-10-09
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ SSD1306 monochrome OLED display.
 
 ### Fixed
 
-- Fixed `BufferedGraphicsMode::clear(On)` such that it fills all pixels with `On`, not only some.
+- [#201](https://github.com/jamwaffles/ssd1306/pull/201) Fixed `BufferedGraphicsMode::clear(On)` such that it fills all pixels with `On`, not only some.
 
 ## [0.8.3] - 2023-10-09
 

--- a/src/mode/buffered_graphics.rs
+++ b/src/mode/buffered_graphics.rs
@@ -69,7 +69,7 @@ where
     SIZE: DisplaySize,
 {
     fn clear_impl(&mut self, value: bool) {
-        self.mode.buffer.as_mut().fill(value as u8);
+        self.mode.buffer.as_mut().fill(if value { 0xff } else { 0 });
 
         let (width, height) = self.dimensions();
         self.mode.min_x = 0;


### PR DESCRIPTION
Hi! Thank you for helping out with SSD1306 development! Please:

- [x] Check that you've added documentation to any new methods
- [x] Rebase from `master` if you're not already up to date
- [x] Add or modify an example if there are changes to the public API
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, **Changed**, etc)
- [x] Run `rustfmt` on the project with `cargo fmt --all` - CI will not pass without this step
- [x] Check that your branch is up to date with master and that CI is passing once the PR is opened

## PR description

Currently `clear()` fills the buffer with `0x01` bytes, which represent
7 dark pixels and 1 bright pixel. We want all pixels bright. This PR fixes it by filling buffer with 0xff.
