### PR TITLE
Add method to release the contained interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ SSD1306 monochrome OLED display.
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- [#203](https://github.com/jamwaffles/ssd1306/pull/203) Added `Ssd1306::release(self)` to release the contained i2c interface.
+
 ## [0.8.4] - 2023-10-27
 
 ### Fixed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -413,6 +413,11 @@ where
             .map(|s| &s[page_lower..page_upper])
             .try_for_each(|c| interface.send_data(U8(&c)))
     }
+
+    /// Release the contained interface.
+    pub fn release(self) -> DI {
+        self.interface
+    }
 }
 
 // SPI-only reset


### PR DESCRIPTION
Hi! Thank you for helping out with SSD1306 development! Please:

- [x] Check that you've added documentation to any new methods
- [x] Rebase from `master` if you're not already up to date
- [ ] Add or modify an example if there are changes to the public API
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, **Changed**, etc)
- [x] Run `rustfmt` on the project with `cargo fmt --all` - CI will not pass without this step
- [x] Check that your branch is up to date with master and that CI is passing once the PR is opened

## PR description

Just a method that consumes the Ssd1306 and returns the contained interface.
