### PR TITLE
Fix TerminalMode::write_str() to write all chars (#228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ SSD1306 monochrome OLED display.
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
+### Fixed
+- Fix TerminalMode::write_str() to write all chars ([#228](https://github.com/rust-embedded-community/ssd1306/issues/228))
+
 ## [0.10.0] - 2025-03-22
 ### Changed
 - Added `DisplaySize64x32` to the prelude

--- a/src/mode/terminal.rs
+++ b/src/mode/terminal.rs
@@ -624,7 +624,8 @@ where
     SIZE: TerminalDisplaySize,
 {
     fn write_str(&mut self, s: &str) -> Result<(), fmt::Error> {
-        s.chars().map(move |c| self.print_char(c)).next_back();
-        Ok(())
+        s.chars()
+            .try_for_each(|c| self.print_char(c))
+            .map_err(|_| fmt::Error)
     }
 }


### PR DESCRIPTION
Hi! Thank you for helping out with SSD1306 development! Please:

- [x] Check that you've added documentation to any new methods
- [x] Rebase from `master` if you're not already up to date
- [x] Add or modify an example if there are changes to the public API
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, **Changed**, etc)
- [x] Run `rustfmt` on the project with `cargo fmt --all` - CI will not pass without this step
- [x] Check that your branch is up to date with master and that CI is passing once the PR is opened

## PR description

This PR fixed the TerminalMode::write_str() bug described in (#228).
