### PR TITLE
perf: implement fill_contiguous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ SSD1306 monochrome OLED display.
 ### Fixed
 - Fix TerminalMode::write_str() to write all chars ([#228](https://github.com/rust-embedded-community/ssd1306/issues/228))
 
+### Added
+- Implement `embedded_graphics::draw_target::DrawTarget::fill_contiguous` to more improve performance when filling
+  contiguous regions.
+
 ## [0.10.0] - 2025-03-22
 ### Changed
 - Added `DisplaySize64x32` to the prelude


### PR DESCRIPTION
A significant amount of CPU time was being spent filling rectangles in my application. I traced most of the problem to `set_pixel` being somewhat slow for large rectangular areas.

By implementing `fill_contiguous` much of the bounds checking and control flow changes for rotation are lifted outside the hot path.

Tested on STM32G0 with 0.96 128x64 OLED over I2C.