### PR TITLE
feat: add 102x64 resolution variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ SSD1306 monochrome OLED display.
 ### Added
 - Implement `embedded_graphics::draw_target::DrawTarget::fill_contiguous` to more improve performance when filling
   contiguous regions.
+- Added `DisplaySize102x64`
 
 ## [0.10.0] - 2025-03-22
 ### Changed

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,7 +9,7 @@ pub use super::{
     mode::DisplayConfig,
     rotation::DisplayRotation,
     size::{
-        DisplaySize, DisplaySize128x32, DisplaySize128x64, DisplaySize64x32, DisplaySize64x48,
+        DisplaySize, DisplaySize102x64, DisplaySize128x32, DisplaySize128x64, DisplaySize64x32, DisplaySize64x48,
         DisplaySize72x40, DisplaySize96x16,
     },
 };

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,8 +9,8 @@ pub use super::{
     mode::DisplayConfig,
     rotation::DisplayRotation,
     size::{
-        DisplaySize, DisplaySize102x64, DisplaySize128x32, DisplaySize128x64, DisplaySize64x32, DisplaySize64x48,
-        DisplaySize72x40, DisplaySize96x16,
+        DisplaySize, DisplaySize102x64, DisplaySize128x32, DisplaySize128x64, DisplaySize64x32,
+        DisplaySize64x48, DisplaySize72x40, DisplaySize96x16,
     },
 };
 

--- a/src/size.rs
+++ b/src/size.rs
@@ -25,7 +25,10 @@ impl<const N: usize> NewZeroed for [u8; N] {
 /// This includes resolution, offset and framebuffer size.
 #[maybe_async_cfg::maybe(
     sync(keep_self),
-    async(feature = "async", idents(WriteOnlyDataCommand(async = "AsyncWriteOnlyDataCommand")))
+    async(
+        feature = "async",
+        idents(WriteOnlyDataCommand(async = "AsyncWriteOnlyDataCommand"))
+    )
 )]
 pub trait DisplaySize {
     /// Width in pixels

--- a/src/size.rs
+++ b/src/size.rs
@@ -25,10 +25,7 @@ impl<const N: usize> NewZeroed for [u8; N] {
 /// This includes resolution, offset and framebuffer size.
 #[maybe_async_cfg::maybe(
     sync(keep_self),
-    async(
-        feature = "async",
-        idents(WriteOnlyDataCommand(async = "AsyncWriteOnlyDataCommand"))
-    )
+    async(feature = "async", idents(WriteOnlyDataCommand(async = "AsyncWriteOnlyDataCommand")))
 )]
 pub trait DisplaySize {
     /// Width in pixels
@@ -77,6 +74,25 @@ pub struct DisplaySize128x64;
 impl DisplaySize for DisplaySize128x64 {
     const WIDTH: u8 = 128;
     const HEIGHT: u8 = 64;
+    type Buffer = [u8; <Self as DisplaySize>::WIDTH as usize *
+        <Self as DisplaySize>::HEIGHT as usize / 8];
+
+    async fn configure(
+        &self,
+        iface: &mut impl WriteOnlyDataCommand,
+    ) -> Result<(), DisplayError> {
+        Command::ComPinConfig(true, false).send(iface).await
+    }
+}
+
+/// Size information for the common 102x64 variants
+#[derive(Debug, Copy, Clone)]
+pub struct DisplaySize102x64;
+#[maybe_async_cfg::maybe(sync(keep_self), async(feature = "async", keep_self))]
+impl DisplaySize for DisplaySize102x64 {
+    const WIDTH: u8 = 102;
+    const HEIGHT: u8 = 64;
+    const OFFSETX: u8 = 13;
     type Buffer = [u8; <Self as DisplaySize>::WIDTH as usize *
         <Self as DisplaySize>::HEIGHT as usize / 8];
 


### PR DESCRIPTION
Hi! Thank you for helping out with SSD1306 development! Please:

- [x] Check that you've added documentation to any new methods
- [x] Rebase from `master` if you're not already up to date
- [x] Add or modify an example if there are changes to the public API
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, **Changed**, etc)
- [x] Run `rustfmt` on the project with `cargo fmt --all` - CI will not pass without this step
- [x] Check that your branch is up to date with master and that CI is passing once the PR is opened

## PR description
Adds the 102x64 resolution, used for example in EA OLEDS102 - a nice display for direct soldering onto PCBs.

<img width="444" height="413" alt="image" src="https://github.com/user-attachments/assets/72e7fda4-40eb-4934-8497-d9e10beee311" />