### PR TITLE
Added function to clear only region of display

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.84
+      - uses: dtolnay/rust-toolchain@1.85
         with:
           components: rustfmt
       - run: cargo fmt --all -- --check
@@ -24,7 +24,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.84
+      - uses: dtolnay/rust-toolchain@1.85
       - run: cargo test --lib --target x86_64-unknown-linux-gnu
       - run: cargo test --doc --target x86_64-unknown-linux-gnu
 
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.84
+      - uses: dtolnay/rust-toolchain@1.85
         with:
           components: rustfmt
       - run: rustup target add ${{matrix.target}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ SSD1306 monochrome OLED display.
 ### Added
 - Implement `embedded_graphics::draw_target::DrawTarget::fill_contiguous` to more improve performance when filling
   contiguous regions.
+- Add `clear_region(x0, y0, x1, y1)` method to `BufferedGraphicsMode` to clear a rectangular region of the framebuffer.
 
 ## [0.10.0] - 2025-03-22
 ### Changed

--- a/examples/clear_region_i2c.rs
+++ b/examples/clear_region_i2c.rs
@@ -1,0 +1,89 @@
+//! Draw a filled rectangle then clear a sub-region of it using `clear_region`.
+//!
+//! This example is for the STM32F103 "Blue Pill" board using I2C1.
+//!
+//! Wiring connections are as follows for a CRIUS-branded display:
+//!
+//! ```
+//!      Display -> Blue Pill
+//! (black)  GND -> GND
+//! (red)    +5V -> VCC
+//! (yellow) SDA -> PB7
+//! (green)  SCL -> PB6
+//! ```
+//!
+//! Run on a Blue Pill with `cargo run --example clear_region_i2c`.
+
+#![no_std]
+#![no_main]
+
+use cortex_m::asm::nop;
+use cortex_m_rt::entry;
+use defmt_rtt as _;
+use embassy_stm32::time::Hertz;
+#[cfg(feature = "async")]
+use embassy_stm32::{bind_interrupts, i2c, peripherals};
+use embedded_graphics::{
+    pixelcolor::BinaryColor,
+    prelude::*,
+    primitives::{PrimitiveStyleBuilder, Rectangle},
+};
+use panic_probe as _;
+use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
+
+#[entry]
+fn main() -> ! {
+    let p = embassy_stm32::init(Default::default());
+    #[cfg(feature = "async")]
+    bind_interrupts!(struct Irqs {
+        I2C1_EV => i2c::EventInterruptHandler<peripherals::I2C1>;
+        I2C1_ER => i2c::ErrorInterruptHandler<peripherals::I2C1>;
+    });
+
+    #[cfg(feature = "async")]
+    let i2c = embassy_stm32::i2c::I2c::new(
+        p.I2C1,
+        p.PB6,
+        p.PB7,
+        Irqs,
+        p.DMA1_CH6,
+        p.DMA1_CH7,
+        Hertz::khz(400),
+        Default::default(),
+    );
+
+    #[cfg(not(feature = "async"))]
+    let i2c = embassy_stm32::i2c::I2c::new_blocking(
+        p.I2C1,
+        p.PB6,
+        p.PB7,
+        Hertz::khz(400),
+        Default::default(),
+    );
+
+    let interface = I2CDisplayInterface::new(i2c);
+    let mut display = Ssd1306::new(interface, DisplaySize128x64, DisplayRotation::Rotate0)
+        .into_buffered_graphics_mode();
+    display.init().unwrap();
+
+    let filled_style = PrimitiveStyleBuilder::new()
+        .fill_color(BinaryColor::On)
+        .build();
+
+    // Draw a filled rectangle covering most of the screen.
+    Rectangle::new(Point::new(10, 10), Size::new(108, 44))
+        .into_styled(filled_style)
+        .draw(&mut display)
+        .unwrap();
+
+    display.flush().unwrap();
+
+    // Clear a rectangular sub-region from the framebuffer, then flush only
+    // the changed area back to the display.
+    display.clear_region(30, 20, 98, 44);
+    display.flush().unwrap();
+
+    loop {
+        nop()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,9 @@ use command::CommandAsync;
 use command::{AddrMode, Command, VcomhLevel};
 #[cfg(feature = "async")]
 use display_interface::AsyncWriteOnlyDataCommand;
-use display_interface::{DataFormat::U8, DisplayError, WriteOnlyDataCommand};
+use display_interface::DataFormat::U8;
+use display_interface::DisplayError;
+use display_interface::WriteOnlyDataCommand;
 use embedded_hal::{delay::DelayNs, digital::OutputPin};
 #[cfg(feature = "async")]
 use embedded_hal_async::delay::DelayNs as DelayNsAsync;

--- a/src/mode/buffered_graphics.rs
+++ b/src/mode/buffered_graphics.rs
@@ -118,6 +118,50 @@ where
         self.clear_impl(false);
     }
 
+    /// Clear a region of the framebuffer.
+    ///
+    /// Clears pixels in the rectangular region from (x0, y0) to (x1, y1).
+    /// You need to call `flush()` to send the cleared region to the display.
+    pub fn clear_region(&mut self, x0: u8, y0: u8, x1: u8, y1: u8) {
+        let (x0, x1) = if x0 <= x1 { (x0, x1) } else { (x1, x0) };
+        let (y0, y1) = if y0 <= y1 { (y0, y1) } else { (y1, y0) };
+
+        let (width, height) = self.dimensions();
+        let x0 = x0.min(width - 1);
+        let x1 = x1.min(width - 1);
+        let y0 = y0.min(height - 1);
+        let y1 = y1.min(height - 1);
+
+        let rotation = self.rotation;
+        match rotation {
+            DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => {
+                for y in y0..=y1 {
+                    for x in x0..=x1 {
+                        let idx = ((y as usize) / 8 * SIZE::WIDTH as usize) + x as usize;
+                        if let Some(byte) = self.mode.buffer.as_mut().get_mut(idx) {
+                            *byte &= !(1 << (y % 8));
+                        }
+                    }
+                }
+            }
+            DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => {
+                for x in x0..=x1 {
+                    for y in y0..=y1 {
+                        let idx = ((x as usize) / 8 * SIZE::WIDTH as usize) + y as usize;
+                        if let Some(byte) = self.mode.buffer.as_mut().get_mut(idx) {
+                            *byte &= !(1 << (x % 8));
+                        }
+                    }
+                }
+            }
+        }
+
+        self.mode.min_x = self.mode.min_x.min(x0);
+        self.mode.max_x = self.mode.max_x.max(x1);
+        self.mode.min_y = self.mode.min_y.min(y0);
+        self.mode.max_y = self.mode.max_y.max(y1);
+    }
+
     /// Write out data to a display.
     ///
     /// This only updates the parts of the display that have changed since the last flush.


### PR DESCRIPTION
Rather than clearing entire screen buffer, just clear a portion of the screen for faster partial writes.

Hi! Thank you for helping out with SSD1306 development! Please:

- [x] Check that you've added documentation to any new methods
- [x] Rebase from `master` if you're not already up to date
- [x] Add or modify an example if there are changes to the public API
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, **Changed**, etc)
- [x] Run `rustfmt` on the project with `cargo fmt --all` - CI will not pass without this step
- [x] Check that your branch is up to date with master and that CI is passing once the PR is opened

## PR description

Awesome repository, I could use it out of the box! I am running on a time-critical MCU, so my writings to the display should be as quick  as possible. However, when writing new text over and existing text will just leave the old text there and overwrite it. That is why I added a function to clear a portion of the screen to allow both a short write and a clear text.

I am, however, not sure I did this in the way we want to design the library. If you are not happy with the current implementation, could you help me (point me) how to do this? 

Thanks,
Martin
