### PR TITLE
Reduce unnecessary chunking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.84
+      - uses: dtolnay/rust-toolchain@1.85
         with:
           components: rustfmt
       - run: cargo fmt --all -- --check
@@ -24,7 +24,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.84
+      - uses: dtolnay/rust-toolchain@1.85
       - run: cargo test --lib --target x86_64-unknown-linux-gnu
       - run: cargo test --doc --target x86_64-unknown-linux-gnu
 
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-            toolchain: 1.75
+            toolchain: 1.85
       - run: cargo build --lib --target x86_64-unknown-linux-gnu
       - run: cargo build --lib --target x86_64-unknown-linux-gnu --features async
       - run: cargo doc --target x86_64-unknown-linux-gnu
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.84
+      - uses: dtolnay/rust-toolchain@1.85
         with:
           components: rustfmt
       - run: rustup target add ${{matrix.target}}
@@ -75,4 +75,3 @@ jobs:
       - if: ${{ matrix.examples }}
         run: cargo build --target ${{matrix.target}} --all-features --examples --release
       - run: cargo doc --all-features --target ${{matrix.target }}
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ SSD1306 monochrome OLED display.
 
 ### Changed
 - Improved interface utilisation when the buffer to be sent is contiguous.
+- **(breaking)** Increased MSRV to 1.85.0, Rust edition to 2024
 
 ## [0.10.0] - 2025-03-22
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ SSD1306 monochrome OLED display.
 - Implement `embedded_graphics::draw_target::DrawTarget::fill_contiguous` to more improve performance when filling
   contiguous regions.
 
+### Changed
+- Improved interface utilisation when the buffer to be sent is contiguous.
+
 ## [0.10.0] - 2025-03-22
 ### Changed
 - Added `DisplaySize64x32` to the prelude

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ name = "ssd1306"
 readme = "README.md"
 repository = "https://github.com/rust-embedded-community/ssd1306"
 version = "0.10.0"
-edition = "2021"
+edition = "2024"
 exclude = ["build.rs", "build.sh", "memory.x", "doc", "*.jpg", "*.png", "*.bmp"]
-rust-version = "1.75.0"
+rust-version = "1.85.0"
 resolver = "2"
 
 [package.metadata.docs.rs]

--- a/examples/async_i2c_spi.rs
+++ b/examples/async_i2c_spi.rs
@@ -30,14 +30,14 @@
 use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_futures::join::join;
-use embassy_stm32::{bind_interrupts, gpio, i2c, peripherals, spi::Spi, time::Hertz, Config};
+use embassy_stm32::{Config, bind_interrupts, gpio, i2c, peripherals, spi::Spi, time::Hertz};
 use embedded_graphics::{
     image::{Image, ImageRaw},
     pixelcolor::BinaryColor,
     prelude::*,
 };
 use panic_probe as _;
-use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306Async};
+use ssd1306::{I2CDisplayInterface, Ssd1306Async, prelude::*};
 
 bind_interrupts!(struct Irqs {
     I2C1_EV => i2c::EventInterruptHandler<peripherals::I2C1>;

--- a/examples/async_terminal_i2c.rs
+++ b/examples/async_terminal_i2c.rs
@@ -21,7 +21,7 @@ use defmt_rtt as _;
 use embassy_executor::Spawner;
 use embassy_stm32::{bind_interrupts, i2c, peripherals, time::Hertz};
 use panic_probe as _;
-use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306Async};
+use ssd1306::{I2CDisplayInterface, Ssd1306Async, prelude::*};
 
 bind_interrupts!(struct Irqs {
     I2C1_EV => i2c::EventInterruptHandler<peripherals::I2C1>;
@@ -52,12 +52,12 @@ async fn main(_spawner: Spawner) {
     loop {
         for c in 97..123 {
             let _ = display
-                .write_str(unsafe { core::str::from_utf8_unchecked(&[c]) })
+                .write_str(unsafe { core::str::from_utf8_unchecked(core::slice::from_ref(&c)) })
                 .await;
         }
         for c in 65..91 {
             let _ = display
-                .write_str(unsafe { core::str::from_utf8_unchecked(&[c]) })
+                .write_str(unsafe { core::str::from_utf8_unchecked(core::slice::from_ref(&c)) })
                 .await;
         }
     }

--- a/examples/bmp_i2c.rs
+++ b/examples/bmp_i2c.rs
@@ -29,7 +29,7 @@ use embassy_stm32::time::Hertz;
 use embassy_stm32::{bind_interrupts, i2c, peripherals};
 use embedded_graphics::{image::Image, pixelcolor::Rgb565, prelude::*};
 use panic_probe as _;
-use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
+use ssd1306::{I2CDisplayInterface, Ssd1306, prelude::*};
 
 use tinybmp::Bmp;
 

--- a/examples/graphics.rs
+++ b/examples/graphics.rs
@@ -35,7 +35,7 @@ use embedded_graphics::{
     primitives::{Circle, PrimitiveStyleBuilder, Rectangle, Triangle},
 };
 use panic_probe as _;
-use ssd1306::{prelude::*, Ssd1306};
+use ssd1306::{Ssd1306, prelude::*};
 
 #[entry]
 fn main() -> ! {

--- a/examples/graphics_i2c.rs
+++ b/examples/graphics_i2c.rs
@@ -29,7 +29,7 @@ use embedded_graphics::{
     primitives::{Circle, PrimitiveStyleBuilder, Rectangle, Triangle},
 };
 use panic_probe as _;
-use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
+use ssd1306::{I2CDisplayInterface, Ssd1306, prelude::*};
 
 #[entry]
 fn main() -> ! {

--- a/examples/graphics_i2c_128x32.rs
+++ b/examples/graphics_i2c_128x32.rs
@@ -29,7 +29,7 @@ use embedded_graphics::{
     primitives::{Circle, PrimitiveStyleBuilder, Rectangle, Triangle},
 };
 use panic_probe as _;
-use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
+use ssd1306::{I2CDisplayInterface, Ssd1306, prelude::*};
 
 #[entry]
 fn main() -> ! {

--- a/examples/graphics_i2c_72x40.rs
+++ b/examples/graphics_i2c_72x40.rs
@@ -29,7 +29,7 @@ use embedded_graphics::{
     primitives::{Circle, PrimitiveStyleBuilder, Rectangle, Triangle},
 };
 use panic_probe as _;
-use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
+use ssd1306::{I2CDisplayInterface, Ssd1306, prelude::*};
 
 #[entry]
 fn main() -> ! {

--- a/examples/image_i2c.rs
+++ b/examples/image_i2c.rs
@@ -36,7 +36,7 @@ use embedded_graphics::{
     prelude::*,
 };
 use panic_probe as _;
-use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
+use ssd1306::{I2CDisplayInterface, Ssd1306, prelude::*};
 
 #[entry]
 fn main() -> ! {

--- a/examples/noise_i2c.rs
+++ b/examples/noise_i2c.rs
@@ -27,7 +27,7 @@ use embassy_stm32::{bind_interrupts, i2c, peripherals};
 use embassy_stm32::time::Hertz;
 use panic_probe as _;
 use rand::prelude::*;
-use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
+use ssd1306::{I2CDisplayInterface, Ssd1306, prelude::*};
 
 #[entry]
 fn main() -> ! {

--- a/examples/pixelsquare.rs
+++ b/examples/pixelsquare.rs
@@ -31,7 +31,7 @@ use embassy_stm32::{
     time::Hertz,
 };
 use panic_probe as _;
-use ssd1306::{prelude::*, Ssd1306};
+use ssd1306::{Ssd1306, prelude::*};
 
 #[entry]
 fn main() -> ! {

--- a/examples/rotation_i2c.rs
+++ b/examples/rotation_i2c.rs
@@ -35,7 +35,7 @@ use embedded_graphics::{
     prelude::*,
 };
 use panic_probe as _;
-use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
+use ssd1306::{I2CDisplayInterface, Ssd1306, prelude::*};
 
 #[entry]
 fn main() -> ! {

--- a/examples/rtic_brightness.rs
+++ b/examples/rtic_brightness.rs
@@ -16,12 +16,11 @@ mod app {
     use defmt_rtt as _;
     use display_interface_spi::SPIInterface;
     use embassy_stm32::{
-        gpio,
+        Config, gpio,
         mode::Blocking,
         spi::{self, Spi},
         time::Hertz,
         timer::low_level::Timer,
-        Config,
     };
     use embedded_graphics::{
         geometry::Point,
@@ -31,7 +30,7 @@ mod app {
         primitives::{PrimitiveStyle, Rectangle},
     };
     use panic_probe as _;
-    use ssd1306::{mode::BufferedGraphicsMode, prelude::*, Ssd1306};
+    use ssd1306::{Ssd1306, mode::BufferedGraphicsMode, prelude::*};
     use tinybmp::Bmp;
 
     type Display = Ssd1306<

--- a/examples/rtic_dvd.rs
+++ b/examples/rtic_dvd.rs
@@ -17,12 +17,11 @@ mod app {
     use defmt_rtt as _;
     use display_interface_spi::SPIInterface;
     use embassy_stm32::{
-        gpio,
+        Config, gpio,
         mode::Blocking,
         spi::{self, Spi},
         time::Hertz,
         timer::low_level::Timer,
-        Config,
     };
     use embedded_graphics::{
         geometry::Point,
@@ -32,7 +31,7 @@ mod app {
         primitives::{PrimitiveStyle, Rectangle},
     };
     use panic_probe as _;
-    use ssd1306::{mode::BufferedGraphicsMode, prelude::*, Ssd1306};
+    use ssd1306::{Ssd1306, mode::BufferedGraphicsMode, prelude::*};
     use tinybmp::Bmp;
 
     type Display = Ssd1306<

--- a/examples/terminal_i2c.rs
+++ b/examples/terminal_i2c.rs
@@ -24,7 +24,7 @@ use embassy_stm32::time::Hertz;
 #[cfg(feature = "async")]
 use embassy_stm32::{bind_interrupts, i2c, peripherals};
 use panic_probe as _;
-use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
+use ssd1306::{I2CDisplayInterface, Ssd1306, prelude::*};
 
 #[entry]
 fn main() -> ! {
@@ -65,10 +65,12 @@ fn main() -> ! {
     /* Endless loop */
     loop {
         for c in 97..123 {
-            let _ = display.write_str(unsafe { core::str::from_utf8_unchecked(&[c]) });
+            let _ = display
+                .write_str(unsafe { core::str::from_utf8_unchecked(core::slice::from_ref(&c)) });
         }
         for c in 65..91 {
-            let _ = display.write_str(unsafe { core::str::from_utf8_unchecked(&[c]) });
+            let _ = display
+                .write_str(unsafe { core::str::from_utf8_unchecked(core::slice::from_ref(&c)) });
         }
     }
 }

--- a/examples/text_i2c.rs
+++ b/examples/text_i2c.rs
@@ -25,13 +25,13 @@ use embassy_stm32::time::Hertz;
 #[cfg(feature = "async")]
 use embassy_stm32::{bind_interrupts, i2c, peripherals};
 use embedded_graphics::{
-    mono_font::{ascii::FONT_6X10, MonoTextStyleBuilder},
+    mono_font::{MonoTextStyleBuilder, ascii::FONT_6X10},
     pixelcolor::BinaryColor,
     prelude::*,
     text::{Baseline, Text},
 };
 use panic_probe as _;
-use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
+use ssd1306::{I2CDisplayInterface, Ssd1306, prelude::*};
 
 #[entry]
 fn main() -> ! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,10 +81,10 @@
 //!
 //! // Spam some characters to the display
 //! for c in 97..123 {
-//!     let _ = display.write_str(unsafe { core::str::from_utf8_unchecked(&[c]) });
+//!     let _ = display.write_str(unsafe { core::str::from_utf8_unchecked(core::slice::from_ref(&c)) });
 //! }
 //! for c in 65..91 {
-//!     let _ = display.write_str(unsafe { core::str::from_utf8_unchecked(&[c]) });
+//!     let _ = display.write_str(unsafe { core::str::from_utf8_unchecked(core::slice::from_ref(&c)) });
 //! }
 //!
 //! // The `write!()` macro is also supported

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -502,15 +502,25 @@ where
         let page_lower = upper_left.0 as usize;
         let page_upper = lower_right.0 as usize;
 
-        for c in buffer
-            .chunks(disp_width)
-            .skip(starting_page)
-            .take(num_pages)
-            .map(|s| &s[page_lower..page_upper])
-        {
-            interface.send_data(U8(c)).await?
+        let is_contiguous = page_lower == 0 && page_upper == SIZE::WIDTH as usize;
+
+        if is_contiguous {
+            interface
+                .send_data(U8(
+                    &buffer[starting_page * disp_width..][..num_pages * disp_width]
+                ))
+                .await
+        } else {
+            for c in buffer
+                .chunks(disp_width)
+                .skip(starting_page)
+                .take(num_pages)
+                .map(|s| &s[page_lower..page_upper])
+            {
+                interface.send_data(U8(c)).await?;
+            }
+            Ok(())
         }
-        Ok(())
     }
 
     /// Release the contained interface.

--- a/src/mode/buffered_graphics.rs
+++ b/src/mode/buffered_graphics.rs
@@ -1,13 +1,13 @@
 //! Buffered graphics mode.
 
 use crate::{
+    Ssd1306,
     command::AddrMode,
     rotation::DisplayRotation,
     size::{DisplaySize, NewZeroed},
-    Ssd1306,
 };
 #[cfg(feature = "async")]
-use crate::{size::DisplaySizeAsync, Ssd1306Async};
+use crate::{Ssd1306Async, size::DisplaySizeAsync};
 #[cfg(feature = "async")]
 use display_interface::AsyncWriteOnlyDataCommand;
 use display_interface::{DisplayError, WriteOnlyDataCommand};
@@ -233,11 +233,11 @@ where
 
 #[cfg(feature = "graphics")]
 use embedded_graphics_core::{
+    Pixel,
     draw_target::DrawTarget,
     geometry::{AnchorX, AnchorY, Dimensions, OriginDimensions, Size},
     pixelcolor::BinaryColor,
     primitives::Rectangle,
-    Pixel,
 };
 
 use super::DisplayConfig;

--- a/src/mode/mod.rs
+++ b/src/mode/mod.rs
@@ -3,7 +3,7 @@
 mod buffered_graphics;
 mod terminal;
 
-use crate::{command::AddrMode, rotation::DisplayRotation, size::DisplaySize, Ssd1306};
+use crate::{Ssd1306, command::AddrMode, rotation::DisplayRotation, size::DisplaySize};
 pub use buffered_graphics::*;
 use display_interface::{DisplayError, WriteOnlyDataCommand};
 pub use terminal::*;

--- a/src/mode/terminal.rs
+++ b/src/mode/terminal.rs
@@ -1,8 +1,8 @@
 #[cfg(feature = "async")]
 use crate::mode::DisplayConfigAsync;
-use crate::{command::AddrMode, mode::DisplayConfig, rotation::DisplayRotation, size::*, Ssd1306};
+use crate::{Ssd1306, command::AddrMode, mode::DisplayConfig, rotation::DisplayRotation, size::*};
 #[cfg(feature = "async")]
-use crate::{size::DisplaySizeAsync, Ssd1306Async};
+use crate::{Ssd1306Async, size::DisplaySizeAsync};
 use core::{cmp::min, fmt};
 #[cfg(feature = "async")]
 use display_interface::AsyncWriteOnlyDataCommand;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,8 +9,8 @@ pub use super::{
     mode::DisplayConfig,
     rotation::DisplayRotation,
     size::{
-        DisplaySize, DisplaySize128x32, DisplaySize128x64, DisplaySize64x32, DisplaySize64x48,
-        DisplaySize72x40, DisplaySize96x16,
+        DisplaySize, DisplaySize64x32, DisplaySize64x48, DisplaySize72x40, DisplaySize96x16,
+        DisplaySize128x32, DisplaySize128x64,
     },
 };
 


### PR DESCRIPTION
Hi! Thank you for helping out with SSD1306 development! Please:

- [x] Check that you've added documentation to any new methods
- [x] Rebase from `master` if you're not already up to date
- [x] Add or modify an example if there are changes to the public API
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, **Changed**, etc)
- [x] Run `rustfmt` on the project with `cargo fmt --all` - CI will not pass without this step
- [x] Check that your branch is up to date with master and that CI is passing once the PR is opened

## PR description

This PR sends contiguous buffers in one operation, instead of chunking it up in 8-pixel tall stripes. If you update the whole display, the underlying display driver can transfer the buffer much more efficiently - in my case, with a 128x64 display, the driver issues a single send_data call instead of 8.

Before (ignore the 8MHz, my logic analyser is too slow to sample the 40MHz clock so it's aliasing):

<img width="1643" height="377" alt="image" src="https://github.com/user-attachments/assets/c4947a5d-ce2b-4bf2-8463-7ac7598895e2" />

After

<img width="904" height="373" alt="image" src="https://github.com/user-attachments/assets/e481e5b7-cb1c-41e9-9586-6eb00ccebfd1" />